### PR TITLE
feat: add SimpleTaskScheduling, SimpleObjectProcessing, and TaskScheduling specs

### DIFF
--- a/.docs/modeling.md
+++ b/.docs/modeling.md
@@ -1,0 +1,122 @@
+# ArmoniK Modeling Using TLA+
+
+**WARNING: This document is a draft. It may not be up to date with the specifications.**
+
+ArmoniK is an existing production-grade system that comprises many lines of code, components and configurations. The purpose of the TLA+ specification is to converge toward the description of the existing system while ensuring correctness. As the system has been developed withou prior formal specification, many aspects need to be precised. 
+
+The aim of this document is therefore to discuss and document the assumptions and modeling choices adopted to formalize ArmoniK's design and algorithms. In particular, it details the model design based on the actual implementation, specifying and justifying the omissions and simplifications made.
+
+When using TLA+, the state of the art modeling approach is iterative through refinement. This is the approach we are about to adopt. We'll start by describing ArmoniK's operation as abstractly as possible, and then move on step by step to a more detailed description.
+
+
+## Table of Contents
+
+## An Abstract Decentralized Online Scheduling System
+
+At the high-level ArmoniK can be seen as a decentralized online task scheduler. It consists of a set of agents known as Scheduling Agents (whose number is unknown and may vary over time) responsible for executing tasks submitted to the system over time.  The constraints of such a system are as follow:
+
+* New tasks can be submitted at any time. As this is an online scheduler, the system can be requested at any time to execute a new set of tasks. The only constraint is that these tasks must be new, i.e. distinct from previously submitted tasks. In other words, tasks are unique and cannot be submitted several times (although this does not mean that the same computation cannot be performed several times).
+* An agent can acquire a set of available tasks (i.e. uncompleted tasks that are not being processed by any other agent) in order to proceed with their execution. To guarantee efficiency, the system seeks to carry out as little work as possible by avoiding performing the same task several times.
+* An agent can release all or part of the tasks it is processing, making them available again. An agent may decide it is enable to execute the task for any reason. In particular, this constraint abstracts many failure scenarios like the crash of the agent. Future refinements will clarify the need for task releasing.
+* An agent can complete all or part of the tasks it is processing. When an agent completes the processing of tasks, it notifies it for an eventual user or to avoid future re-executions.
+
+The system must be designed to guarantee the following properties:
+* A task cannot be executed simultaneously by two separate agents.
+* Any task submitted must be finally completed.
+* Once completed a task remains completed forever.
+
+> **Remark**: A task abstracts a request of performing a compution i.e executing a set of instructions.
+
+A status is associated to each task to track its position in the scheduling process. Based on the previous informal description, it is possible to scheme the life-cycle of a task as shown on the following figure.
+
+```mermaid
+stateDiagram-v2
+direction LR
+
+    [*] --> Submitted : Submit
+    Submitted --> Started : Schedule
+    Started --> Completed : Release
+    Started --> Submitted : Complete
+
+    classDef completed fill:#006400
+    class Completed completed
+```
+
+In this diagram each state correspond to a given status for a task and the transitions describe the system as a transition system. This transition system associated with the desired properties is specified in [SimpleTaskScheduling](../specs/SimpleTaskGraphScheduling.tla).
+
+> **Note**: One of the difficulties in writing the specification is that you have to be able to write the set of tasks, which is proiri infinite. Similarly, the set of agents is unknown and potentially very large. In both cases, we represent a task (respectively an agent) by a unique identifier taken from any set. The set of task (respectively agent) identifiers is not explicitly described and is given as a constant in the specification. This corresponds to describing the system as being parameterized with two parameters.
+
+> **Note**: To model check the specification, both task and agent identifier sets must be materialized and finite. During model checking, as the number of task is finite, the system reaches an unrelevant deadlock when all tasks have been executed. To overcome this, a dedicated specification extends the previous for model-checking purpose and introduce a dummy terminating action that avoid the deadlock. This specification is [MCSimpleTaskScheduling](../specs/MCSimpleTaskScheduling.tla).
+
+## Considering Task Inputs/Outputs
+
+The previous description omits tasks I/Os that play a central role in ArmoniK as they are used to express dependencies between tasks. Indeed a task perform computation on data, it consumes inputs to produce outputs. Data are the counterparts of tasks, in that their processing is comparable to that of tasks, and the properties associated with their process are complementary to those associated with tasks. The previous specification can therefore be refined to integrate tasks I/Os into the description.
+
+To simplify and clarify this refinement we do it in two steps:
+1. We write an abstract specification that states how data are processed.
+2. We write a refined specification that states tasks scheduling with their I/Os.
+
+> **Remark**: Just as a task abstracts the notion of computation, we need an abstraction of the notion of data. This abstraction is called *object* and encapsulates all the information relating to a particular piece of data.
+
+### Abstract Object Processing
+
+As with tasks, we're not interested in the value of the data, but in the way it's processed by the system. This is what object abstraction is for. In the following, we'll only be talking about objects.
+
+From the high-level ArmoniK manages a collection of individual objects identified by à unique identifier. Regarding these objects it enforces the following constraints:
+* An object can be created empty. An empty object simply means that there exists a container for a data but this data is not yet available.
+* An empty object can be completed. It means that at any time an empty object can be completed by providing its data.
+* An object can be created completed. It means that the object is provided with its data when created. (This corresponds to the composition of the two previous actions. It seems less relevant and will probably removed in future versions of the specification.)
+* A completed object can be locked to forbid its overwriting. Once a data is consumed, we don't want it to be modified as it could lead to unexpected behaviors in the computation.
+
+The system design must guarantee the following properties:
+* All object must eventually be completed.
+* Once locked an object remains locked forever i.e it cannot be overwritten (= returning to the completed state).
+
+> **Note**: (Move this note to rational of locking constraint) In the early drafts of the specification, objects were supposed to be immutable. However, this poses an obvious problem when considering failures during task execution. Indeed, if a task crashes after writing its first result, it must be able to overwrite it during future executions (unless the object is cloned, which poses other problems). The immutability property was therefore abandoned in favor of object locking.
+
+Like with data, a status is associated to each object to track its processing state. Based on the previous informal description, it is possible to scheme the life-cycle of an object as shown on the following figure.
+
+```mermaid
+stateDiagram-v2
+direction LR
+
+    [*] --> Created : CreateEmpty
+    [*] --> Completed : CreateCompleted
+    Created --> Completed : Complete
+    Completed --> Locked : Lock
+    Locked --> Locked : Lock
+
+    classDef locked fill:#006400
+    class Locked locked
+```
+
+In this diagram each state correspond to a given status for an object and the transitions describe the system as a transition system. This transition system associated with the desired properties is specified in [SimpleObjectProcessing](../specs/SimpleObjectProcessing.tla).
+
+> **Note**: SimpleObjectProcessing specification also uses an implict set for object identifiers. A dedicated specification [MCSimpleObjectProcessing](../specs/MCSimpleObjectProcessing.tla) is used for model-checking.
+
+### Abstract task scheduling with I/Os
+
+## Adding task dependencies
+
+The task scheduling system specified above only deals with independent tasks. We now couple task scheduling with object processing while precising relevant constraints to describe the scheduling of dynamic task graphs. This new specification is a refinement of the SimpleTaskScheduling specification.
+
+A decentralized dynamic task graph scheduler is a system similar to the one described above, but in which tasks consume and produce data represented by objects. This data is used to account for the dependencies between tasks (and therefore their order of execution). A key aspect of this system is that it allows submission of tasks and objects at runtime leading to restructuring of the task graph. Some guards must be enforced to ensure consistency and avoid deadlocks. This system inherits the constraints and properties of both SimpleTaskScheduling and SimpleObjectProcessing to which are added:
+- The task and object dependencies forms a bipartite directed-acyclic graph whose roots and leaves are objects and where every objects has at most a single predecessors (i.e an object is completed either by environment or produced by a single task). **Rational**: It guarantees that every task has at least one input and one output object and that tasks cannot deadlock because of circular dependencies.
+- Task dependencies once submitted can't be modified.
+- A task can be schedule once all its input objects are completed.
+- Once consumed, objects are locked i.e once a task having it as input is scheduled.
+- A task cannot complete until all its output objects are completed. It may occurs later however.
+- Task dependencies can be resolved only after its completion. Task resolution consists in submitting newly ready tasks.
+- When a task dynamically submit a sub graph the following must hold: tasks can take any existing or newly created object as input and have any new object as output or those of the parent task performing subtasking. In particular it is forbidden for a task to become the parent of other existing objects.
+- Add the constraints related to subtasking.
+
+The system must guarantee the following properties:
+* The task graph is always consistent (has the required structure).
+* 
+* Refines the two previous specifications.
+
+**Thoughts**:
+- Tasks and data must be processed in the order defined by the task/data graph (topological sorting? Historical variable?).
+- See if it is possible to draw a state diagram inspring from automata composition.
+
+**IMPORTANT**: In all the spec described so far, tasks, objects and agents are identified by labels called identifiers. Swapping these labels doesn't change the behavior of the system. This encourage to use symetry reduction.

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ modules/dist/
 
 # Ignore TLC generated files
 *.out
+*.dot
 */states
 
 # Ignore PDF, DVI and TEX files

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tools/
 modules/tlc/
 modules/build/
 modules/dist/
+modules/lib/
 
 # Ignore TTrace specs
 *_TTrace_*.tla

--- a/specs/MCSimpleObjectProcessing.cfg
+++ b/specs/MCSimpleObjectProcessing.cfg
@@ -1,0 +1,25 @@
+CONSTANTS
+    \* Object identifiers (model values)
+    ObjectId = {o, p, q}
+    
+    \* Object status values (model values)
+    NULL = NULL
+    CREATED = CREATED
+    COMPLETED = COMPLETED
+    LOCKED = LOCKED
+
+    \* Override Next with bounded-model-checking version
+    Next <- MCNext
+
+
+SPECIFICATION
+    Spec
+
+
+INVARIANTS
+    TypeInv
+
+
+PROPERTIES
+    EventualCompletion
+    Quiescence

--- a/specs/MCSimpleObjectProcessing.tla
+++ b/specs/MCSimpleObjectProcessing.tla
@@ -1,0 +1,40 @@
+----------------------- MODULE MCSimpleObjectProcessing ------------------------
+(******************************************************************************)
+(* Bounded model-checking extension of SimpleObjectScheduling.                *)
+(*                                                                            *)
+(* For model checking, the set of object identifiers must be finite and       *)
+(* explicitly materialized. Since the number of objects is finite, the system *)
+(* eventually reaches a state where all objects are completed, which leads to *)
+(* an artificial deadlock.                                                    *)
+(*                                                                            *)
+(* To avoid this spurious deadlock, the next-state action is overridden to    *)
+(* include a dummy terminal state, allowing the model checker to terminate    *)
+(* exploration gracefully.                                                    *)
+(******************************************************************************)
+EXTENDS FiniteSets, SimpleObjectProcessing
+
+ASSUME IsFiniteSet(ObjectId)
+
+--------------------------------------------------------------------------------
+
+(**
+ * Dummy action representing the terminal state of the system, reached once all
+ * objects have been completed.
+ *)
+Terminating ==
+    /\ \A o \in ObjectId: IsCompleted({o}) \/ IsLocked({o})
+    /\ UNCHANGED vars
+
+(**
+ * Modified next-state action. Extends the original system behavior with the
+ * Terminating action to avoid artificial deadlocks due to the bounded object
+ * set.
+ *)
+MCNext ==
+    \/ \E S \in SUBSET ObjectId:
+        \/ Create(S)
+        \/ Complete(S)
+        \/ Lock(S)
+    \/ Terminating
+
+================================================================================

--- a/specs/MCSimpleTaskScheduling.cfg
+++ b/specs/MCSimpleTaskScheduling.cfg
@@ -1,0 +1,31 @@
+CONSTANTS
+    \* Agent identifiers (model values)
+    AgentId = {a, b, c}
+
+    \* Task identifiers (model values)
+    TaskId = {t, u, v}
+
+    \* Task status values (model values)
+    NULL      = NULL
+    SUBMITTED = SUBMITTED
+    STARTED   = STARTED
+    COMPLETED = COMPLETED
+
+    \* Override Next with bounded-model-checking version
+    Next <- MCNext
+
+
+SPECIFICATION
+    Spec
+
+
+INVARIANTS
+    TypeInv
+    ExecutionConsistency
+    StatusConsistency
+    NoExecutionConcurrency
+
+
+PROPERTY
+    EventualCompletion
+    Quiescence

--- a/specs/MCSimpleTaskScheduling.tla
+++ b/specs/MCSimpleTaskScheduling.tla
@@ -1,0 +1,60 @@
+------------------------ MODULE MCSimpleTaskScheduling -------------------------
+(******************************************************************************)
+(* Bounded model-checking extension of SimpleTaskScheduling.                  *)
+(*                                                                            *)
+(* For model checking, both the sets of task identifiers and agent            *)
+(* identifiers must be finite and explicitly materialized. Since the          *)
+(* number of tasks is finite, the system eventually reaches a state where all *)
+(* tasks are executed, which leads to an artificial deadlock.                 *)
+(*                                                                            *)
+(* To avoid this spurious deadlock, the next-state action is overridden to    *)
+(* include a dummy terminal state, allowing the model checker to terminate    *)
+(* exploration gracefully.                                                    *)
+(******************************************************************************)
+EXTENDS FiniteSets, SimpleTaskScheduling
+
+ASSUME IsFiniteSet(TaskId)
+ASSUME IsFiniteSet(AgentId)
+
+--------------------------------------------------------------------------------
+
+(**
+ * Dummy action representing the terminal state of the system, reached once all
+ * tasks have been completed.
+ *)
+Terminating ==
+    /\ IsCompleted(TaskId)
+    /\ UNCHANGED vars
+
+(**
+ * Modified next-state action. Extends the original system behavior with the
+ * Terminating action to avoid artificial deadlocks due to the bounded task set.
+ *)
+MCNext ==
+    \/ \E S \in SUBSET TaskId:
+        \/ Submit(S)
+        \/ \E a \in AgentId:
+            \/ Schedule(a, S)
+            \/ Release(a, S)
+            \/ Complete(a, S)
+    \/ Terminating
+
+--------------------------------------------------------------------------------
+
+(**
+ * Sanity invariant: The set of all scheduled tasks is always a subset of the
+ * overall task set.
+ *)
+ExecutionConsistency ==
+    UNION {alloc[a]: a \in AgentId} \subseteq {t: t \in TaskId}
+
+(**
+ * Sanity invariant: A task is assigned to some agent if and only if it is in the
+ * STARTED state.
+ *)
+StatusConsistency ==
+    \A t \in TaskId:
+        \/ IsStarted({t}) /\ \E a \in AgentId: t \in alloc[a]
+        \/ ~IsStarted({t}) /\ \A a \in AgentId: t \notin alloc[a]
+
+================================================================================

--- a/specs/MCTaskScheduling.cfg
+++ b/specs/MCTaskScheduling.cfg
@@ -1,0 +1,37 @@
+CONSTANTS
+    \* Agent identifiers (model values)
+    AgentId = {a, b}
+
+    \* Object identifiers (model values)
+    ObjectId = {o, p, q}
+
+    \* Task identifiers (model values)
+    TaskId = {t, u}
+
+    \* Task and object status values (model values)
+    NULL = NULL
+    CREATED = CREATED
+    SUBMITTED = SUBMITTED
+    STARTED = STARTED
+    COMPLETED = COMPLETED
+    LOCKED = LOCKED
+
+    \* Override Next with bounded-model-checking version
+    Next <- MCNext
+
+
+SPECIFICATION
+    Spec
+
+
+INVARIANTS
+    TypeInv
+
+
+PROPERTIES
+    ImplementsSimpleTaskScheduling
+    ImplementsSimpleObjectProcessing
+
+
+\* SYMMETRY
+\*     Symmetry

--- a/specs/MCTaskScheduling.tla
+++ b/specs/MCTaskScheduling.tla
@@ -1,0 +1,57 @@
+--------------------------- MODULE MCTaskScheduling ----------------------------
+(******************************************************************************)
+(* Bounded model-checking extension of TaskScheduling.                        *)
+(*                                                                            *)
+(* For model checking, the sets of task, objects and agent identifiers  must  *)
+(* be finite and explicitly materialized. Since the number of tasks and       *)
+(* objects are finite, the system eventually reaches a state where all tasks  *)
+(* and objects are completed, which leads to an artificial deadlock.          *)
+(*                                                                            *)
+(* To avoid this spurious deadlock, the next-state action is overridden to    *)
+(* include a dummy terminal state, allowing the model checker to terminate    *)
+(* exploration gracefully.                                                    *)
+(******************************************************************************)
+EXTENDS TaskScheduling, TLC
+
+ASSUME IsFiniteSet(AgentId)
+ASSUME IsFiniteSet(ObjectId)
+ASSUME IsFiniteSet(TaskId)
+
+--------------------------------------------------------------------------------
+
+(**
+ * Dummy action representing the terminal state of the system, reached once all
+ * tasks and objectshave been completed.
+ *)
+Terminating ==
+    /\ \A t \in TaskId: ~ STS!IsUnknown({t}) => STS!IsCompleted({t})
+    /\ \A o \in ObjectId: ~ SOP!IsUnknown({o}) => \/ SOP!IsCompleted({o})
+                                                  \/ SOP!IsLocked({o})
+    /\ UNCHANGED vars
+
+(**
+ * Modified next-state action. Extends the original system behavior with the
+ * Terminating action to avoid artificial deadlocks due to the bounded task
+ * and object sets.
+ *)
+MCNext ==
+    \/ \E S \in SUBSET ObjectId:
+        \/ CreateObjects(S)
+        \/ CompleteObjects(S)
+    \/ \E G \in ACGraphs(TaskId \ UsedTaskId, ObjectId): SubmitTasks(G)
+    \/ \E S \in SUBSET TaskId, a \in AgentId:
+        \/ ScheduleTasks(a, S)
+        \/ ReleaseTasks(a, S)
+        \/ CompleteTasks(a, S)
+    \/ \E S \in SUBSET TaskId: ResolveTasks(S)
+    \/ Terminating
+
+--------------------------------------------------------------------------------
+
+(**
+ * Symmetry relation between task, object and agent identifiers.
+ *)
+Symmetry ==
+    Permutations(TaskId) \union Permutations(ObjectId) \union Permutations(AgentId)
+
+================================================================================

--- a/specs/SimpleObjectProcessing.tla
+++ b/specs/SimpleObjectProcessing.tla
@@ -1,0 +1,118 @@
+------------------------ MODULE SimpleObjectProcessing -------------------------
+(******************************************************************************)
+(* This specification models an abstract data management system. Data are     *)
+(* represented as uniquely identified objects. The specification abstracts    *)
+(* from the internal contents of objects and focuses solely on their          *)
+(* lifecycle and processing.                                                  *)
+(******************************************************************************)
+CONSTANT
+    ObjectId    \* Set of object identifiers (theoretically infinite).
+
+CONSTANTS
+    NULL,      \* Status of an object not yet known to the system.
+    CREATED,   \* Status of a known object whose data is empty.
+    COMPLETED, \* Status of an object whose data has been completed.
+    LOCKED     \* Status of an object whose data can no longer be overwritten.
+
+VARIABLES
+    status     \* status[o] is the status of object o.
+
+(**
+ * Tuple of all variables.
+ *)
+vars == << status >>
+
+--------------------------------------------------------------------------------
+
+(**
+ * Type invariant property.
+ *)
+TypeInv ==
+    \* Each object is always in one of the four possible states.
+    status \in [ObjectId -> {NULL, CREATED, COMPLETED, LOCKED}]
+
+(**
+ * Helpers to check the uniform status of a set of objects.
+ *)
+IsInStatus(S, STATUS) ==
+    \A x \in S: status[x] = STATUS
+
+IsUnknown(S)   == IsInStatus(S, NULL)
+IsCreated(S)   == IsInStatus(S, CREATED)
+IsCompleted(S) == IsInStatus(S, COMPLETED)
+IsLocked(S)    == IsInStatus(S, LOCKED)
+
+--------------------------------------------------------------------------------
+
+(**
+ * Initial state predicate: No objects are stored in the system.
+ *)
+Init ==
+    status = [o \in ObjectId |-> NULL]
+
+(**
+ * Action predicate: A non-empty set S of new objects is created.
+ *)
+Create(S) ==
+    /\ S /= {} /\ IsUnknown(S)
+    /\ status' = [o \in ObjectId |-> IF o \in S THEN CREATED ELSE status[o]]
+
+(**
+ * Action predicate: A non-empty set S of objects is completed, i.e., their data
+ * is written. For objects whose data already exists, it is overwritten.
+ *)
+Complete(S) ==
+    /\ S /= {} /\ (\A o \in S: IsCreated({o}) \/ IsCompleted({o}))
+    /\ status' = [o \in ObjectId |-> IF o \in S THEN COMPLETED ELSE status[o]]
+
+(**
+ * Action predicate: A non-empty set S of objects are locked, preventing the
+ * associated data from being overwritten.
+ *)
+Lock(S) ==
+    /\ S /= {} /\ (\A o \in S: IsCompleted({o}) \/ IsLocked({o}))
+    /\ status' = [o \in ObjectId |-> IF o \in S THEN LOCKED ELSE status[o]]
+
+(**
+ * Next-state relation.
+ *)
+Next ==
+    \E S \in SUBSET ObjectId:
+        \/ Create(S)
+        \/ Complete(S)
+        \/ Lock(S)
+
+--------------------------------------------------------------------------------
+
+(**
+ * Full system specification with fairness properties.
+ *)
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    \* Weak fairness property: All objects stored in the system have their data
+    \* eventually completed.
+    /\ \A S \in SUBSET ObjectId: WF_vars(Complete(S))
+
+--------------------------------------------------------------------------------
+
+(**
+ * Liveness property: Every created object is eventually completed.
+ *)
+EventualCompletion ==
+    \A o \in ObjectId: IsCreated({o}) ~> IsCompleted({o})
+
+(**
+ * Liveness property: Once an object (or set of objects) is locked, it stays
+ * locked forever.
+ *)
+Quiescence ==
+    \A S \in SUBSET ObjectId: [](IsLocked(S) => []IsLocked(S))
+
+--------------------------------------------------------------------------------
+
+THEOREM Spec => []TypeInv
+THEOREM Spec => EventualCompletion
+THEOREM Spec => Quiescence
+
+================================================================================

--- a/specs/SimpleTaskScheduling.tla
+++ b/specs/SimpleTaskScheduling.tla
@@ -1,0 +1,149 @@
+------------------------- MODULE SimpleTaskScheduling --------------------------
+(******************************************************************************)
+(* This specification models a decentralized online task scheduling system**  *)
+(* in which dynamically submitted tasks are executed by a varying unknown     *)
+(* number of agents.                                                          *)
+(*                                                                            *)
+(* The specification abstracts away from concrete execution policies,         *)
+(* focusing on the possible behaviors of task assignment and progress.        *)
+(******************************************************************************)
+CONSTANTS
+    AgentId,    \* Set of agent identifiers (theoretically infinite).
+    TaskId      \* Set of task identifiers (theoretically infinite).
+
+CONSTANTS
+    NULL,       \* Status of a task not yet known to the system.
+    SUBMITTED,  \* Status of a task ready for execution.
+    STARTED,    \* Status of a task currently being processed.
+    COMPLETED   \* Status of a task that has been successfully processed.
+
+VARIABLES
+    alloc,      \* alloc[a] is the set of tasks currently scheduled on agent a.
+    status      \* status[t] is the execution status of task t.
+
+(**
+ * Tuple of all variables.
+ *)
+vars == << alloc, status >>
+
+--------------------------------------------------------------------------------
+
+(**
+ * Type invariant property.
+ *)
+TypeInv ==
+    \* Each agent is associated with a subset of tasks.
+    /\ alloc \in [AgentId -> SUBSET TaskId]
+    \* Each task has one of the four possible states.
+    /\ status \in [TaskId -> {NULL, SUBMITTED, STARTED, COMPLETED}]
+
+(**
+ * Helpers to check the uniform status of a set of tasks.
+ *)
+IsInStatus(S, STATUS) ==
+    \A t \in S: status[t] = STATUS
+
+IsUnknown(S)   == IsInStatus(S, NULL)
+IsSubmitted(S) == IsInStatus(S, SUBMITTED)
+IsStarted(S)   == IsInStatus(S, STARTED)
+IsCompleted(S) == IsInStatus(S, COMPLETED)
+
+--------------------------------------------------------------------------------
+
+(**
+ * Initial state predicate: No tasks are submitted or scheduled.
+ *)
+Init ==
+    /\ alloc = [a \in AgentId |-> {}]
+    /\ status = [t \in TaskId |-> NULL]
+
+(**
+ * Action predicate: A non-empty set S of previously unknown tasks is submitted,
+ * i.e., made available for scheduling.
+ *)
+Submit(S) ==
+    /\ S /= {} /\ IsUnknown(S)
+    /\ status' = [t \in TaskId |-> IF t \in S THEN SUBMITTED ELSE status[t]]
+    /\ UNCHANGED alloc
+
+(**
+ * Action predicate: A non-empty set S of submitted tasks are scheduled on
+ * agent a.
+ *)
+Schedule(a, S) ==
+    /\ S /= {} /\ IsSubmitted(S)
+    /\ alloc' = [alloc EXCEPT ![a] = @ \union S]
+    /\ status' = [t \in TaskId |-> IF t \in S THEN STARTED ELSE status[t]]
+
+(**
+ * Action predicate: Agent a releases a non-empty set S of tasks that it
+ * currently holds.
+ *)
+Release(a, S) ==
+    /\ S /= {} /\ S \subseteq alloc[a]
+    /\ alloc' = [alloc EXCEPT ![a] = @ \ S]
+    /\ status' = [t \in TaskId |-> IF t \in S THEN SUBMITTED ELSE status[t]]
+
+(**
+ * Action predicate: Agent a completes the execution of a non-empty set S of
+ * tasks that it currently holds.
+ *)
+Complete(a, S) == 
+    /\ S /= {} /\ S \subseteq alloc[a]
+    /\ alloc' = [alloc EXCEPT ![a] = @ \ S]
+    /\ status' = [t \in TaskId |-> IF t \in S THEN COMPLETED ELSE status[t]]
+
+(**
+ * Next-state relation.
+ *)
+Next == 
+    \E S \in SUBSET TaskId:
+        \/ Submit(S)
+        \/ \E a \in AgentId:
+            \/ Schedule(a, S)
+            \/ Release(a, S)
+            \/ Complete(a, S)
+
+--------------------------------------------------------------------------------
+
+(**
+ * Full system specification with fairness properties.
+ *)
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    \* Weak fairness property: Ready tasks cannot wait indefinitely and end up
+    \* being scheduled on an agent.
+    /\ \A S \in SUBSET TaskId: WF_vars(\E a \in AgentId: Schedule(a, S))
+    \* Strong fairness property: Tasks cannot run indefinitely or be
+    \* systematically released.
+    /\ \A S \in SUBSET TaskId: SF_vars(\E a \in AgentId: Complete(a, S))
+
+--------------------------------------------------------------------------------
+
+(**
+ * Invariant: A task cannot be executed simultaneously by multiple agents.
+ *)
+NoExecutionConcurrency ==
+    \A a, b \in AgentId: a /= b => alloc[a] \intersect alloc[b] = {}
+
+(**
+ * Liveness property: Any submitted task is eventually completed.
+ *)
+EventualCompletion ==
+    \A S \in SUBSET TaskId: IsSubmitted(S) ~> IsCompleted(S)
+
+(**
+ * Liveness property: Once a task is completed, it remains completed forever.
+ *)
+Quiescence ==
+    \A S \in SUBSET TaskId: [](IsCompleted(S) => []IsCompleted(S))
+
+--------------------------------------------------------------------------------
+
+THEOREM Spec => []TypeInv
+THEOREM Spec => []NoExecutionConcurrency
+THEOREM Spec => EventualCompletion
+THEOREM Spec => Quiescence
+
+================================================================================

--- a/specs/TaskScheduling.tla
+++ b/specs/TaskScheduling.tla
@@ -1,0 +1,272 @@
+------------------------- MODULE TaskScheduling -------------------------
+(***********************************************************************)
+(* This specification models an online decentralized distributed task  *)
+(* graph scheduling system where:                                      *)
+(*   - Tasks have input/output data abstracted by objects.             *)
+(*   - Tasks can depend on each other via their input/output data.     *)
+(*   - Agents (workers) execute tasks.                                      *)
+(*   - Tasks and objects are dynamically submitted over time.               *)
+(****************************************************************************)
+EXTENDS FiniteSets, GraphsExt, Naturals
+
+CONSTANTS
+    AgentId,    \* Set of agent identifiers (theoretically infinite).
+    ObjectId,   \* Set of object identifiers (theoretically infinite).
+    TaskId      \* Set of task identifiers (theoretically infinite).
+
+CONSTANTS
+    NULL,       \* Status of a task/object not yet known to the system.
+    CREATED,    \* Status of a task/object submitted/created.
+    SUBMITTED,  \* Status of a task ready for execution.
+    STARTED,    \* Status of a task currently being processed.
+    COMPLETED,  \* Status of a task/object that has been successfully completed.
+    LOCKED      \* Status of an object whose data can no longer be overwritten.
+
+VARIABLES
+    alloc,        \* alloc[a] is the set of tasks currently scheduled on agent a.
+    objectStatus, \* objectStatus[o] is the status of object o.
+    taskStatus,   \* taskStatus[t] is the execution status of task t.
+    deps          \* dependencies between tasks and objects as a directed graph
+                  \* whose nodes deps.node are task or object identifiers, and
+                  \* whose edges deps.edge represent the data dependencies between
+                  \* tasks.
+
+(**
+ * Tuple of all variables.
+ *)
+vars == << alloc, objectStatus, taskStatus, deps >>
+
+--------------------------------------------------------------------------------
+
+(**
+ * Instances of the specifications handling scheduling lifecycle of tasks.
+ * State variable `status` is mapped to 'taskStatus'.
+ *)
+STS == INSTANCE SimpleTaskScheduling WITH status <- taskStatus
+
+(**
+ * Instance of the specfication handling object processing.
+ * State variable `status` is mapped to 'objectStatus'.
+ *)
+SOP == INSTANCE SimpleObjectProcessing WITH status <- objectStatus
+
+--------------------------------------------------------------------------------
+
+(**
+ * Type invariant property.
+ *)
+TypeInv ==
+    \* Each agent is associated with a subset of tasks.
+    /\ alloc \in [AgentId -> SUBSET TaskId]
+    \* Each task has one of the five possible status.
+    /\ taskStatus \in [TaskId -> {NULL, CREATED, SUBMITTED, STARTED, COMPLETED}]
+    \* Each object has one of the four possible status.
+    /\ SOP!TypeInv
+    \* Dependcy graph is an instance of an ArmoniK-compliant task graph.
+    /\ deps \in ACGraphs(TaskId, ObjectId)
+
+(**
+ * Set of all parent tasks (i.e., the closest predecessor tasks) of the tasks in
+ * set S.
+ *)
+ParentTasks(S) ==
+    UNION {
+        {m \in TaskId:
+            \E o \in ObjectId:
+                (<< m, o >> \in deps.edge) /\ (<< o, n >> \in deps.edge)
+        }: n \in S
+    }
+
+(**
+ * Set of task identifiers that have already been used, i.e., associated with a
+ * task already known to the system.
+ *)
+UsedTaskId == {id \in TaskId: taskStatus[id] /= NULL}
+
+(**
+ * Helper to check if all tasks in S are in CREATED state.
+ *)
+IsCreated(S) ==
+    \A t \in S: taskStatus[t] = CREATED
+
+--------------------------------------------------------------------------------
+
+(**
+ * Initial state predicate:
+ *  - No tasks are submitted or scheduled.
+ *  - No object is known.
+ *  - Dependency graph is empty.
+ *)
+Init ==
+    /\ STS!Init
+    /\ SOP!Init
+    /\ deps = EmptyGraph
+
+(**
+ * Action predicate: A non-empty set S of new objects is created.
+ *)
+CreateObjects(S) ==
+    /\ SOP!Create(S)
+    /\ UNCHANGED << alloc, taskStatus, deps >>
+
+(**
+ * Action predicate: A non-empty set S of objects is completed, i.e., their data
+ * is written. For objects whose data already exists, it is overwritten.
+ * Objects can be completed when:
+ *   - they are not the outputs of any task (the set of predecessors is empty),
+ *     which corresponds to external completion by the user.
+ *   - they are the outputs of tasks currently being executed on the same agent,
+ *     which corresponds to writing the result of these tasks.
+ * TODO: Currently execution on the same agent is not checked. It is so ar no clear
+ * if this condition is really needed.
+ *)
+CompleteObjects(S) ==
+    /\ STS!IsStarted(UNION {Predecessors(o, deps): o \in S})
+    /\ SOP!Complete(S)
+    /\ UNCHANGED << alloc, taskStatus, deps >>
+
+(**
+ * Action predicate: A new graph of tasks is submitted to the system. This graph
+ * can extend the existing one or be fully disconnected. In any case, it must
+ * preserve the integrity of the dependency graph, i.e., the union must remain
+  * ArmoniK-compliant.In addition, extending the dependency graph is only
+  * permitted if it does not modify the dependencies of objects that have
+  * already been completed.
+ *)
+SubmitTasks(G) ==
+    LET newDeps == GraphUnion(deps, G)
+    IN /\ newDeps /= EmptyGraph
+       /\ newDeps \in ACGraphs(TaskId, ObjectId)
+       /\ SOP!IsCreated({ v \in G.node : v \in ObjectId })
+       /\ taskStatus' =
+            [ t \in TaskId |->
+                IF t \in G.node
+                    THEN IF SOP!IsCompleted(Predecessors(t, newDeps))
+                         THEN SUBMITTED
+                         ELSE CREATED
+                    ELSE taskStatus[t]
+            ]
+       /\ deps' = newDeps
+       /\ UNCHANGED << alloc, objectStatus >>
+
+(**
+ * Action predicate: A non-empty set S of submitted tasks are scheduled on
+ * agent a. Scheduling is only permitted if all input objects are complete or
+ * locked. Scheduling a task triggers the locking of its input objects.
+ *)
+ScheduleTasks(a, S) ==
+    /\ SOP!Lock(UNION {Predecessors(t, deps): t \in S})
+    /\ STS!Schedule(a, S)
+    /\ UNCHANGED << deps >>
+
+(**
+ * Action predicate: Agent a releases a non-empty set S of tasks that it
+ * currently holds. This can occur regardless of whether a task has
+ * completed all or part of its output objects.
+ *)
+ReleaseTasks(a, S) ==
+    /\ STS!Release(a, S)
+    /\ UNCHANGED << objectStatus, deps >>
+
+(**
+ * Action predicate: Agent a completes the execution of a non-empty set S of
+ * tasks that it currently holds. A task can only be completed if all of its
+ * output objects have been completed.
+ *)
+CompleteTasks(a, S) ==
+    /\ SOP!IsCompleted(UNION {Successors(t, deps): t \in S})
+    /\ STS!Complete(a, S)
+    /\ UNCHANGED << objectStatus, deps >>
+
+(**
+ * Action predicate: A non-empty set S of tasks are made ready (CREATED ->
+ * SUBMITTED) provided that they are known and all their input objects and
+ * parent tasks are completed.
+ *)
+ResolveTasks(S) ==
+    /\ S /= {}
+    /\ \A x \in UNION {Predecessors(t, deps): t \in S}: SOP!IsCompleted({x}) \/ SOP!IsLocked({x})
+    /\ STS!IsCompleted(ParentTasks(S)) /\ IsCreated(S)
+    /\ taskStatus' = [t \in TaskId |-> IF t \in S THEN SUBMITTED ELSE taskStatus[t]]
+    /\ UNCHANGED << alloc, objectStatus, deps >>
+
+--------------------------------------------------------------------------------
+
+(**
+ * Next-state relation.
+ *)
+Next ==
+    \/ \E S \in SUBSET ObjectId:
+        \/ CreateObjects(S)
+        \/ CompleteObjects(S)
+    \/ \E G \in ACGraphs(TaskId \ UsedTaskId, ObjectId): SubmitTasks(G)
+    \/ \E S \in SUBSET TaskId, a \in AgentId:
+        \/ ScheduleTasks(a, S)
+        \/ ReleaseTasks(a, S)
+        \/ CompleteTasks(a, S)
+    \/ \E S \in SUBSET TaskId: ResolveTasks(S)
+
+--------------------------------------------------------------------------------
+
+(**
+ * Full system specification with fairness properties.
+ *)
+Spec ==
+    /\ Init /\ [][Next]_vars
+    \* Weak fairness property: Ready tasks cannot wait indefinitely and end up
+    \* being scheduled on an agent.
+    /\ \A S \in SUBSET TaskId: WF_vars(\E a \in AgentId: ScheduleTasks(a, S))
+    \* Strong fairness property: Objects cannot remain incomplete indefinitely.
+    \* In particular, if a task is executed multiple times, it eventually
+    \* completes its output objects.
+    /\ \A S \in SUBSET ObjectId: SF_vars(CompleteObjects(S))
+    \* Strong fairness property: Tasks cannot run indefinitely or be
+    \* systematically released.
+    /\ \A S \in SUBSET TaskId: SF_vars(\E a \in AgentId: CompleteTasks(a, S))
+    \* Weak fairness property: Tasks whose parents have been completed cannot
+    \* remain unavailable indefinitely and eventually become ready.
+    /\ \A S \in SUBSET TaskId: WF_vars(ResolveTasks(S))
+
+--------------------------------------------------------------------------------
+
+\* TODO: additional properties to consider / rewrite
+
+\* UniqueObjectOwner ==
+\*     \A o \in ObjectId: Cardinality(ObjectTaskOwners(o)) <= 1
+
+\* AllInputsLocked ==
+\*     \A t \in TaskId: STS!IsStarted({t}) \/ STS!IsCompleted({t}) => SOP!IsLocked(ins[t])
+
+\* AllOutputsCompleted ==
+\*     \A t \in TaskId: STS!IsCompleted({t}) => \/ SOP!IsCompleted(outs[t])
+\*                                              \/ SOP!IsLocked(outs[t])
+
+(**
+ * Refinement mapping to SimpleTaskScheduling. Adding dependencies introduces
+ * the CREATED status for a task that is known but not yet ready to be
+ * executed. For the higher-level specification, this is equivalent to
+ * considering the task as unknown to the system (NULL status).
+ *)
+Mapping ==
+    INSTANCE SimpleTaskScheduling WITH
+        status <- [t \in TaskId |-> IF taskStatus[t] = CREATED THEN NULL ELSE taskStatus[t]]
+
+(**
+ * Liveness property: This specification refines the SimpleTaskScheduling
+ * specification.
+ *)
+ImplementsSimpleTaskScheduling == Mapping!Spec
+
+(**
+ * Liveness property: This specification refines the SimpleObjectProcessing
+ * specification.
+ *)
+ImplementsSimpleObjectProcessing == SOP!Spec
+
+--------------------------------------------------------------------------------
+
+THEOREM Spec => []TypeInv
+THEOREM Spec => ImplementsSimpleTaskScheduling
+THEOREM Spec => ImplementsSimpleObjectProcessing
+
+================================================================================


### PR DESCRIPTION
Ces spécifications établissent les premiers jalons de la spécification d'ArmoniK. Elles décrivent de manière abstraite et haut niveau le fonctionnement de l'ordonnanceur: le cycle de vie des tâches et des données ainsi que la gestion des dépendances. Elles posent également les propriétés de bases attendues.

Les éléments suivant ne sont pas encore pris en compte à ce stade:
- la propagation des erreurs au sein du graphe de tâches;
- le subtasking (ability for a task to submit a sub-graph at runtime).