### PR TITLE
feat: add ObjectProcessing3 specification

### DIFF
--- a/specs/ObjectProcessing1.cfg
+++ b/specs/ObjectProcessing1.cfg
@@ -1,13 +1,12 @@
 CONSTANTS
-    \* Object identifiers (model values)
-    ObjectId = {o, p, q}
+    Object = {o, p, q}
+    IsDenumerableSet <- IsFiniteSet
 
 SPECIFICATION
     Spec
 
 INVARIANTS
-    TypeInv
-    DistinctObjectStates
+    TypeOk
     TargetValidity
 
 PROPERTIES

--- a/specs/ObjectProcessing1.tla
+++ b/specs/ObjectProcessing1.tla
@@ -13,7 +13,7 @@ EXTENDS DenumerableSets
 CONSTANTS
     Object  \* Abstract set of all objects
 
-ASSUMPTION
+ASSUMPTION OP1Assumptions ==
     IsDenumerableSet(Object) \* Object is an infinitely countable set
 
 VARIABLES

--- a/specs/ObjectProcessing1.tla
+++ b/specs/ObjectProcessing1.tla
@@ -8,8 +8,13 @@
 (* of the system.                                                            *)
 (*****************************************************************************)
 
+EXTENDS DenumerableSets
+
 CONSTANTS
-    ObjectId   \* Set of object identifiers (theoretically infinite)
+    Object  \* Abstract set of all objects
+
+ASSUMPTION
+    IsDenumerableSet(Object) \* Object is an infinitely countable set
 
 VARIABLES
     objectState,  \* objectState[o] records the current lifecycle state of object o
@@ -20,10 +25,11 @@ vars == << objectState, objectTargets >>
 -------------------------------------------------------------------------------
 
 (**
- * Instance of the ObjectStates module with SetOfObjectsIn operator provided.
+ * Imports the definition of the states of objects and sets of objects sharing
+ * the same state.
  *)
 INSTANCE ObjectStates
-    WITH SetOfObjectsIn <- LAMBDA s : {o \in ObjectId: objectState[o] = s}
+    WITH SetOfObjectsIn <- LAMBDA s : {o \in Object: objectState[o] = s}
 
 (**
  * TYPE INVARIANT
@@ -31,13 +37,9 @@ INSTANCE ObjectStates
  *   - objectState is a function mapping each object to one of the defined states.
  *   - objectTargets is a subset of valid object identifiers.
  *)
-TypeInv ==
-    /\ objectState \in [ObjectId -> {
-            OBJECT_UNKNOWN,
-            OBJECT_REGISTERED,
-            OBJECT_FINALIZED
-        }]
-    /\ objectTargets \in SUBSET ObjectId
+TypeOk ==
+    /\ objectState \in [Object -> OP1State]
+    /\ objectTargets \in SUBSET Object
 
 -------------------------------------------------------------------------------
 
@@ -50,7 +52,7 @@ TypeInv ==
  * Initially, all objects are unknown and none are marked as targets.
  *)
 Init ==
-    /\ objectState = [o \in ObjectId |-> OBJECT_UNKNOWN]
+    /\ objectState = [o \in Object |-> OBJECT_UNKNOWN]
     /\ objectTargets = {}
 
 (**
@@ -61,7 +63,7 @@ Init ==
 RegisterObjects(O) ==
     /\ O /= {} /\ O \subseteq UnknownObject
     /\ objectState' =
-        [o \in ObjectId |-> IF o \in O THEN OBJECT_REGISTERED ELSE objectState[o]]
+        [o \in Object |-> IF o \in O THEN OBJECT_REGISTERED ELSE objectState[o]]
     /\ UNCHANGED objectTargets
 
 (**
@@ -91,7 +93,7 @@ UntargetObjects(O) ==
 FinalizeObjects(O) ==
     /\ O /= {} /\ O \subseteq RegisteredObject
     /\ objectState' =
-        [o \in ObjectId |-> IF o \in O THEN OBJECT_FINALIZED ELSE objectState[o]]
+        [o \in Object |-> IF o \in O THEN OBJECT_FINALIZED ELSE objectState[o]]
     /\ UNCHANGED objectTargets
 
 (**
@@ -114,7 +116,7 @@ Terminating ==
  * Defines all possible atomic transitions of the system.
  *)
 Next ==
-    \/ \E O \in SUBSET ObjectId:
+    \/ \E O \in SUBSET Object:
         \/ RegisterObjects(O)
         \/ TargetObjects(O)
         \/ UntargetObjects(O)
@@ -128,9 +130,8 @@ Next ==
  *     eventually finalized.
  *)
 Fairness ==
-    \A o \in ObjectId:
-        EventuallyFinalized(o) ::
-            WF_vars(o \in objectTargets /\ FinalizeObjects({o}))
+    \A o \in Object:
+        WF_vars(o \in objectTargets /\ FinalizeObjects({o}))
 
 (**
  * Full system specification.
@@ -158,7 +159,7 @@ TargetValidity ==
  * Once an object reaches the FINALIZED state, it remains there permanently.
  *)
 PermanentFinalization ==
-    \A o \in ObjectId:
+    \A o \in Object:
         [](o \in FinalizedObject => [](o \in FinalizedObject))
 
 (**
@@ -166,7 +167,7 @@ PermanentFinalization ==
  * Every targeted object is eventually either finalized or untargeted.
  *)
 EventualTargetFinalization ==
-    \A o \in ObjectId:
+    \A o \in Object:
         <>[](o \in objectTargets) => <>(o \in FinalizedObject)
 
 (**
@@ -175,7 +176,7 @@ EventualTargetFinalization ==
  * meaning it is either finalized or removed from the target set.
  *)
 EventualTargetResolution ==
-    \A o \in ObjectId :
-        o \in objectTargets ~> (o \in FinalizedObject \/ o \notin objectTargets)
+    \A o \in Object :
+        o \in objectTargets ~> (o \in FinalizedObject \/ ~ o \in objectTargets)
 
 ================================================================================

--- a/specs/ObjectProcessing1_proofs.tla
+++ b/specs/ObjectProcessing1_proofs.tla
@@ -1,111 +1,101 @@
 ----------------------- MODULE ObjectProcessing1_proofs ------------------------
 EXTENDS ObjectProcessing1, TLAPS
 
-LEMMA LemmaTypeCorrect == Init /\ [][Next]_vars => []TypeInv
-<1>. USE DEF OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_FINALIZED, UnknownObject,
-             RegisteredObject, FinalizedObject
-<1>1. Init => TypeInv
-    BY DEF Init, TypeInv
-<1>2. TypeInv /\ [Next]_vars => TypeInv'
-    BY DEF TypeInv, Next, vars, RegisterObjects, TargetObjects,
-            UntargetObjects, FinalizeObjects, Terminating
+USE DEF OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_FINALIZED
+
+LEMMA LemType == Init /\ [][Next]_vars => []TypeOk
+<1>. USE DEF TypeOk, OP1State, UnknownObject, RegisteredObject, FinalizedObject
+<1>1. Init => TypeOk
+    BY DEF Init
+<1>2. TypeOk /\ [Next]_vars => TypeOk'
+    BY DEF Next, vars, RegisterObjects, TargetObjects, UntargetObjects,
+    FinalizeObjects, Terminating
 <1>. QED
     BY <1>1, <1>2, PTL
 
-THEOREM TypeCorrect == Spec => []TypeInv
-BY LemmaTypeCorrect DEF Spec
+THEOREM OP1_Type == Spec => []TypeOk
+BY LemType DEF Spec
 
-THEOREM DistinctObjectStatesCorrect == Spec => []DistinctObjectStates
-<1>. USE DEF IsPairwiseDisjoint, OBJECT_UNKNOWN, OBJECT_REGISTERED,
-         OBJECT_FINALIZED, OBJECT_COMPLETED, OBJECT_ABORTED, OBJECT_DELETED,
-         UnknownObject, RegisteredObject, FinalizedObject, CompletedObject,
-         AbortedObject, DeletedObject
-<1>1. Init => DistinctObjectStates
-    BY DEF Init, DistinctObjectStates
-<1>2. TypeInv /\ DistinctObjectStates /\ [Next]_vars => DistinctObjectStates'
-    BY DEF TypeInv, DistinctObjectStates, Next, vars, RegisterObjects,
-       TargetObjects, UntargetObjects, FinalizeObjects, Terminating
-<1>. QED
-    BY <1>1, <1>2, TypeCorrect, PTL DEF Spec
-
-THEOREM TargetValidityCorrect == Spec => []TargetValidity
-<1>. USE DEF OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_FINALIZED, UnknownObject,
-             RegisteredObject, FinalizedObject
+LEMMA LemTargetValidity == Init /\ [][Next]_vars => []TargetValidity
+<1>. USE DEF TargetValidity, UnknownObject, RegisteredObject, FinalizedObject
 <1>1. Init => TargetValidity
-    BY DEF Init, TargetValidity
-<1>2. TypeInv /\ TargetValidity /\ [Next]_vars => TargetValidity'
-    BY DEF TargetValidity, TypeInv, Next, vars, RegisterObjects,
-            TargetObjects, UntargetObjects, FinalizeObjects, Terminating
+    BY DEF Init
+<1>2. TypeOk /\ TargetValidity /\ [Next]_vars => TargetValidity'
+    BY DEF TypeOk, Next, vars, RegisterObjects, TargetObjects, UntargetObjects,
+    FinalizeObjects, Terminating
 <1>. QED
-    BY <1>1, <1>2, TypeCorrect, PTL DEF Spec
+    BY <1>1, <1>2, LemType, PTL
+
+THEOREM OP1_TargetValidity == Spec => []TargetValidity
+BY LemTargetValidity DEF Spec
 
 ObjectSafetyInv ==
-    /\ TypeInv
-    /\ DistinctObjectStates
+    /\ TypeOk
     /\ TargetValidity
 
-THEOREM ObjectSafetyInvCorrect == Spec => []ObjectSafetyInv
-BY TypeCorrect, DistinctObjectStatesCorrect, TargetValidityCorrect, PTL
-   DEF ObjectSafetyInv
+LEMMA LemObjectSafetyInv == Init /\ [][Next]_vars => []ObjectSafetyInv
+BY LemType, LemTargetValidity, PTL DEF ObjectSafetyInv
 
-THEOREM PermanentFinalizationCorrect == Spec => PermanentFinalization
-<1>. SUFFICES ASSUME NEW o \in ObjectId
+THEOREM OP1_ObjectSafetyInv == Spec => []ObjectSafetyInv
+BY LemObjectSafetyInv DEF Spec
+
+THEOREM OP1_PermanentFinalization == Spec => PermanentFinalization
+<1>. SUFFICES ASSUME NEW o \in Object
               PROVE Spec => [](o \in FinalizedObject => [](o \in FinalizedObject))
     BY DEF PermanentFinalization
-<1>. USE DEF OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_FINALIZED, UnknownObject,
-             RegisteredObject, FinalizedObject
-<1>1. TypeInv /\ o \in FinalizedObject /\ [Next]_vars
+<1>1. ObjectSafetyInv /\ o \in FinalizedObject /\ [Next]_vars
         => (o \in FinalizedObject)'
-    BY DEF TypeInv, Next, vars, RegisterObjects, TargetObjects,
-            UntargetObjects, FinalizeObjects, Terminating
+    BY DEF ObjectSafetyInv, TypeOk, OP1State, Next, vars, RegisterObjects,
+    TargetObjects, UntargetObjects, FinalizeObjects, Terminating, UnknownObject,
+    RegisteredObject, FinalizedObject
 <1>. QED
-    BY <1>1, TypeCorrect, PTL DEF Spec
+    BY <1>1, OP1_ObjectSafetyInv, PTL DEF Spec
 
-LEMMA TargetsAreKnown == ASSUME NEW o \in objectTargets
-                         PROVE ObjectSafetyInv => \/ o \in RegisteredObject
-                                                  \/ o \in FinalizedObject
-BY DEF ObjectSafetyInv, TypeInv, DistinctObjectStates, TargetValidity,
-       OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_FINALIZED, UnknownObject,
-       RegisteredObject, FinalizedObject
+LEMMA LemTargetsAreKnown ==
+        ASSUME NEW o \in objectTargets, ObjectSafetyInv
+        PROVE o \in RegisteredObject \/ o \in FinalizedObject
+BY DEF ObjectSafetyInv, TypeOk, OP1State, TargetValidity, UnknownObject,
+RegisteredObject, FinalizedObject
 
-THEOREM EventualTargetFinalizationCorrect == Spec => EventualTargetFinalization
-<1>. SUFFICES ASSUME NEW o \in ObjectId
+THEOREM OP1_EventualTargetFinalizationCorrect == Spec => EventualTargetFinalization
+<1>. SUFFICES ASSUME NEW o \in Object
               PROVE Spec => (<>[](o \in objectTargets) => <>(o \in FinalizedObject))
     BY DEF EventualTargetFinalization            
-<1>1. Fairness => Fairness!EventuallyFinalized(o)
+<1>. DEFINE WF == WF_vars(o \in objectTargets /\ FinalizeObjects({o}))
+<1>1. Fairness => WF
     BY DEF Fairness
-<1>2. []ObjectSafetyInv /\ [][Next]_vars /\ Fairness!EventuallyFinalized(o) /\ [](o \in objectTargets)
+<1>2. []ObjectSafetyInv /\ [][Next]_vars /\ WF /\ [](o \in objectTargets)
         => <>(o \in FinalizedObject)
-    <2>. USE DEF OBJECT_FINALIZED, FinalizedObject
+    <2>. USE DEF FinalizedObject
     <2>1. ObjectSafetyInv /\ (o \in objectTargets) /\ ~(o \in FinalizedObject)
             => ENABLED <<o \in objectTargets /\ FinalizeObjects({o})>>_vars
-        BY ExpandENABLED, TargetsAreKnown DEF FinalizeObjects, vars
+        BY ExpandENABLED, LemTargetsAreKnown DEF FinalizeObjects, vars
     <2>2. <<o \in objectTargets /\ FinalizeObjects({o})>>_vars => (o \in FinalizedObject)'
         BY DEF FinalizeObjects, vars
     <2>3. QED
         BY <2>1, <2>2, PTL
 <1> QED
-    BY <1>1, <1>2, PTL, ObjectSafetyInvCorrect DEF Spec
+    BY <1>1, <1>2, PTL, OP1_ObjectSafetyInv DEF Spec
 
-THEOREM EventualTargetResolutionCorrect == Spec => EventualTargetResolution
-<1>. SUFFICES ASSUME NEW o \in ObjectId
-              PROVE Spec => (o \in objectTargets ~> (o \in FinalizedObject \/ o \notin objectTargets))
+THEOREM OP1_EventualTargetResolution == Spec => EventualTargetResolution
+<1>. SUFFICES ASSUME NEW o \in Object
+              PROVE Spec => (o \in objectTargets ~> (o \in FinalizedObject \/ ~ o \in objectTargets))
     BY DEF EventualTargetResolution
 <1>1. o \in objectTargets /\ [Next]_vars => \/ (o \in objectTargets)'
                                             \/ (o \in FinalizedObject)'
                                             \/ (o \notin objectTargets)'
     BY DEF Next, vars, RegisterObjects, TargetObjects, UntargetObjects,
-           FinalizeObjects, Terminating
+    FinalizeObjects, Terminating
 <1>2. <<o \in objectTargets /\ FinalizeObjects({o})>>_vars
         => (o \in FinalizedObject)'
     BY DEF FinalizeObjects, OBJECT_REGISTERED, OBJECT_FINALIZED,
-           RegisteredObject, FinalizedObject
+    RegisteredObject, FinalizedObject
 <1>3. ObjectSafetyInv /\ o \in objectTargets => ENABLED <<o \in objectTargets /\ FinalizeObjects({o})>>_vars \/ o \in FinalizedObject
-    BY ExpandENABLED, TargetsAreKnown DEF FinalizeObjects, vars,
-       OBJECT_REGISTERED, OBJECT_FINALIZED, RegisteredObject, FinalizedObject
-<1>4. Fairness => Fairness!EventuallyFinalized(o)
+    BY ExpandENABLED, LemTargetsAreKnown DEF FinalizeObjects, vars,
+    RegisteredObject, FinalizedObject
+<1>4. Fairness => WF_vars(o \in objectTargets /\ FinalizeObjects({o}))
     BY DEF Fairness
 <1>. QED
-    BY <1>1, <1>2, <1>3, <1>4, ObjectSafetyInvCorrect, PTL DEF Spec, ObjectSafetyInv
+    BY <1>1, <1>2, <1>3, <1>4, OP1_ObjectSafetyInv, PTL DEF Spec, ObjectSafetyInv
 
 ================================================================================

--- a/specs/ObjectProcessing2.cfg
+++ b/specs/ObjectProcessing2.cfg
@@ -1,14 +1,13 @@
 CONSTANTS
-    \* Object identifiers (model values)
-    ObjectId = {o, p, q}
+    Object = {o, p, q}
+    IsDenumerableSet <- IsFiniteSet
 
 SPECIFICATION
     Spec
 
 INVARIANTS
-    TypeInv
-    DistinctObjectStates
+    TypeOk
 
 PROPERTIES
     PermanentFinalization
-    RefineObjectProcessing
+    RefineObjectProcessing1

--- a/specs/ObjectProcessing2.tla
+++ b/specs/ObjectProcessing2.tla
@@ -61,7 +61,7 @@ TypeOk ==
  * wants these objects to be finalized (completed or aborted).
  *)
 TargetObjects(O) ==
-    /\ O # {} /\ O \in UNION {RegisteredObject, CompletedObject, AbortedObject}
+    /\ O # {} /\ O \subseteq UNION {RegisteredObject, CompletedObject, AbortedObject}
     /\ objectTargets' = objectTargets \union O
     /\ UNCHANGED objectState
 
@@ -108,9 +108,9 @@ Terminating ==
  *)
 Next ==
     \/ \E O \in SUBSET Object:
+        \/ OP1!RegisterObjects(O)
         \/ TargetObjects(O)
         \/ OP1!UntargetObjects(O)
-        \/ OP1!RegisterObjects(O)
         \/ CompleteObjects(O)
         \/ AbortObjects(O)
     \/ Terminating

--- a/specs/ObjectProcessing2.tla
+++ b/specs/ObjectProcessing2.tla
@@ -16,7 +16,7 @@ EXTENDS DenumerableSets
 CONSTANTS
     Object  \* Abstract set of all objects
 
-ASSUMPTION
+ASSUMPTION OP2Assumptions ==
     IsDenumerableSet(Object) \* Object is an infinitely countable set
 
 VARIABLES
@@ -160,7 +160,7 @@ objectStateBar ==
           [] objectState[o] = OBJECT_ABORTED   -> OBJECT_FINALIZED
           [] OTHER                             -> objectState[o]
     ]
-OP1Abs == INSTANCE ObjectProcessing1 WITH objectState <- objectStateBar
+OP1Abs == INSTANCE ObjectProcessing1_proofs WITH objectState <- objectStateBar
 RefineObjectProcessing1 == OP1Abs!Spec
 
 ================================================================================

--- a/specs/ObjectProcessing2.tla
+++ b/specs/ObjectProcessing2.tla
@@ -1,19 +1,23 @@
 --------------------------- MODULE ObjectProcessing2 ---------------------------
 (*****************************************************************************)
 (* This module specifies an extended object lifecycle system that refines    *)
-(* the 'ObjectProcessing' specification. It provides a more granular         *)
+(* the 'ObjectProcessing1' specification. It provides a more granular        *)
 (* implementation of the finalization process by decomposing the abstract    *)
 (* FINALIZED state into two concrete outcomes: COMPLETED and ABORTED.        *)
 (*                                                                           *)
 (* The specification defines a refinement mapping that projects these        *)
-(* detailed states back onto the abstract states of 'ObjectProcessing',      *)
+(* detailed states back onto the abstract states of 'ObjectProcessing1',     *)
 (* while asserting that the system's targeting behaviors and safety          *)
 (* invariants remain consistent across this refinement.                      *)
 (*****************************************************************************)
-EXTENDS Utils
+
+EXTENDS DenumerableSets
 
 CONSTANTS
-    ObjectId   \* Set of object identifiers (theoretically infinite)
+    Object  \* Abstract set of all objects
+
+ASSUMPTION
+    IsDenumerableSet(Object) \* Object is an infinitely countable set
 
 VARIABLES
     objectState,  \* objectState[o] records the current lifecycle state of object o
@@ -24,13 +28,14 @@ vars == << objectState, objectTargets >>
 -------------------------------------------------------------------------------
 
 (**
- * Instance of the ObjectStates module with SetOfObjectsIn operator provided.
+ * Imports the definition of the states of objects and sets of objects sharing
+ * the same state.
  *)
 INSTANCE ObjectStates
-    WITH SetOfObjectsIn <- LAMBDA s : {o \in ObjectId: objectState[o] = s}
+    WITH SetOfObjectsIn <- LAMBDA s : {o \in Object: objectState[o] = s}
 
 (**
- * Instance of the ObjectProcessing specification.
+ * Imports ObjectProcessing1 definitions.
  *)
 OP1 == INSTANCE ObjectProcessing1
 
@@ -40,14 +45,9 @@ OP1 == INSTANCE ObjectProcessing1
  *   - objectState is a function mapping each object to one of the defined states.
  *   - objectTargets is a subset of valid object identifiers.
  *)
-TypeInv ==
-    /\ objectState \in [ObjectId -> {
-            OBJECT_UNKNOWN,
-            OBJECT_REGISTERED,
-            OBJECT_COMPLETED,
-            OBJECT_ABORTED
-        }]
-    /\ objectTargets \in SUBSET ObjectId
+TypeOk ==
+    /\ objectState \in [Object -> OP2State]
+    /\ objectTargets \in SUBSET Object
 
 -------------------------------------------------------------------------------
 
@@ -61,29 +61,31 @@ TypeInv ==
  * wants these objects to be finalized (completed or aborted).
  *)
 TargetObjects(O) ==
-    /\ O # {} /\ O \subseteq RegisteredObject \union CompletedObject \union AbortedObject
+    /\ O # {} /\ O \in UNION {RegisteredObject, CompletedObject, AbortedObject}
     /\ objectTargets' = objectTargets \union O
     /\ UNCHANGED objectState
 
 (**
  * OBJECT FINALIZATION
- * A set 'O' of objects is finalized, meaning that these objects are now
- * immutable (will never be modified). Two scenarios are possible:
- *   - objects are completed, meaning that their data has been written and
- *     will never be overwritten
- *   - objects are aborted, meaning that their data cannot be written and never
- *     will be.
+ * A set 'O' of objects is completed, meaning that their data has been
+ * written and will never be modified.
  *)
-FinalizeObjects(O) ==
+CompleteObjects(O) ==
     /\ O /= {} /\ O \subseteq RegisteredObject
-    /\ \E C, A \in SUBSET O :
-        /\ C \union A = O
-        /\ C \intersect  A = {}
-        /\ objectState' =
-            [o \in ObjectId |-> CASE o \in C -> OBJECT_COMPLETED
-                                  [] o \in A -> OBJECT_ABORTED
-                                  [] OTHER   -> objectState[o]]
-        /\ UNCHANGED objectTargets
+    /\ objectState' =
+        [o \in Object |-> IF o \in O THEN OBJECT_COMPLETED ELSE objectState[o]]
+    /\ UNCHANGED objectTargets
+
+(**
+ * OBJECT FINALIZATION
+ * A set 'O' of objects is aborted, meaning that these objects have been
+ * generated with empty data and no data will never be provided.
+ *)
+AbortObjects(O) ==
+    /\ O /= {} /\ O \subseteq RegisteredObject
+    /\ objectState' =
+        [o \in Object |-> IF o \in O THEN OBJECT_ABORTED ELSE objectState[o]]
+    /\ UNCHANGED objectTargets
 
 (**
  * TERMINAL STATE
@@ -105,12 +107,13 @@ Terminating ==
  * Defines all possible atomic transitions of the system.
  *)
 Next ==
-    \E O \in SUBSET ObjectId:
+    \/ \E O \in SUBSET Object:
         \/ TargetObjects(O)
         \/ OP1!UntargetObjects(O)
         \/ OP1!RegisterObjects(O)
-        \/ FinalizeObjects(O)
-        \/ Terminating
+        \/ CompleteObjects(O)
+        \/ AbortObjects(O)
+    \/ Terminating
 
 (**
  * FAIRNESS CONDITIONS
@@ -119,8 +122,9 @@ Next ==
  *     eventually finalized (completed or aborted).
  *)
 Fairness ==
-    \A o \in ObjectId :
-        WF_vars(o \in objectTargets /\ FinalizeObjects({o}))
+    \A o \in Object :
+        /\ WF_vars(o \in objectTargets /\ CompleteObjects({o}))
+        /\ WF_vars(o \in objectTargets /\ AbortObjects({o}))
 
 (**
  * Full system specification.
@@ -142,21 +146,21 @@ Spec ==
  * permanently.
  *)
 PermanentFinalization ==
-    \A o \in ObjectId:
+    \A o \in Object:
         /\ [](o \in CompletedObject => [](o \in CompletedObject))
         /\ [](o \in AbortedObject => [](o \in AbortedObject))
 
 (**
  * LIVENESS
- * This specification refines the ObjectProcessing specification.
+ * This specification refines the ObjectProcessing1 specification.
  *)
 objectStateBar ==
-    [o \in ObjectId |->
+    [o \in Object |->
         CASE objectState[o] = OBJECT_COMPLETED -> OBJECT_FINALIZED
           [] objectState[o] = OBJECT_ABORTED   -> OBJECT_FINALIZED
           [] OTHER                             -> objectState[o]
     ]
-OP1Abs == INSTANCE ObjectProcessing1_proofs WITH objectState <- objectStateBar
-RefineObjectProcessing == OP1Abs!Spec
+OP1Abs == INSTANCE ObjectProcessing1 WITH objectState <- objectStateBar
+RefineObjectProcessing1 == OP1Abs!Spec
 
 ================================================================================

--- a/specs/ObjectProcessing2_proofs.tla
+++ b/specs/ObjectProcessing2_proofs.tla
@@ -2,102 +2,109 @@
 EXTENDS ObjectProcessing2, TLAPS
 
 USE DEF OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_FINALIZED, OBJECT_COMPLETED,
-        OBJECT_ABORTED, OBJECT_DELETED
+OBJECT_ABORTED, OBJECT_DELETED, OP1!OBJECT_UNKNOWN, OP1!OBJECT_REGISTERED, OP1!OBJECT_FINALIZED
 
-USE DEF OP1!OBJECT_UNKNOWN, OP1!OBJECT_REGISTERED, OP1!OBJECT_FINALIZED
-
-THEOREM TypeCorrect == Spec => []TypeInv
-<1>1. OP1!Init => TypeInv
-    BY DEF OP1!Init, TypeInv
-<1>2. TypeInv /\ [Next]_vars => TypeInv'
-    BY DEF TypeInv, Next, vars, TargetObjects, OP1!UntargetObjects,
-           OP1!RegisterObjects, FinalizeObjects, Terminating, UnknownObject,
-           RegisteredObject, CompletedObject, AbortedObject
+LEMMA LemType == OP1!Init /\ [][Next]_vars => []TypeOk
+<1>. USE DEF TypeOk, OP2State
+<1>1. OP1!Init => TypeOk
+    BY DEF OP1!Init
+<1>2. TypeOk /\ [Next]_vars => TypeOk'
+    BY DEF Next, vars, TargetObjects, OP1!UntargetObjects, OP1!RegisterObjects,
+    CompleteObjects, AbortObjects, Terminating, UnknownObject, RegisteredObject,
+    CompletedObject, AbortedObject
 <1>. QED
-    BY <1>1, <1>2, PTL DEF Spec
+    BY <1>1, <1>2, PTL
 
-THEOREM DistinctObjectStatesCorrect == Spec => []DistinctObjectStates
-<1>. USE DEF UnknownObject, RegisteredObject, FinalizedObject, CompletedObject,
-             AbortedObject, DeletedObject
-<1>1. OP1!Init => DistinctObjectStates
-    BY DEF OP1!Init, DistinctObjectStates, IsPairwiseDisjoint
-<1>2. TypeInv /\ DistinctObjectStates /\ [Next]_vars => DistinctObjectStates'
-    BY DEF TypeInv, DistinctObjectStates, IsPairwiseDisjoint, Next, vars,
-       TargetObjects, OP1!UntargetObjects, OP1!RegisterObjects, FinalizeObjects,
-       Terminating
-<1>. QED
-    BY <1>1, <1>2, TypeCorrect, PTL DEF Spec
+THEOREM OP2_Type == Spec => []TypeOk
+BY LemType DEF Spec
 
-THEOREM PermanentFinalizationCorrect == Spec => PermanentFinalization
-<1>. SUFFICES ASSUME NEW o \in ObjectId
+THEOREM OP2_PermanentFinalization == Spec => PermanentFinalization
+<1>. SUFFICES ASSUME NEW o \in Object
               PROVE Spec => /\ [](o \in CompletedObject => [](o \in CompletedObject))
                             /\ [](o \in AbortedObject => [](o \in AbortedObject))
     BY DEF PermanentFinalization
 <1>. USE DEF Next, vars, TargetObjects, OP1!UntargetObjects, OP1!RegisterObjects,
-         FinalizeObjects, Terminating, OP1!UnknownObject, RegisteredObject,
-         CompletedObject, AbortedObject
-<1>1. o \in CompletedObject /\ [Next]_vars
-        => (o \in CompletedObject)'
+     CompleteObjects, AbortObjects, Terminating, OP1!UnknownObject,
+     RegisteredObject, CompletedObject, AbortedObject
+<1>1. o \in CompletedObject /\ [Next]_vars => (o \in CompletedObject)'
     OBVIOUS
-<1>2. o \in AbortedObject /\ [Next]_vars
-        => (o \in AbortedObject)'
+<1>2. o \in AbortedObject /\ [Next]_vars => (o \in AbortedObject)'
     OBVIOUS
 <1>. QED
     BY <1>1, <1>2, PTL DEF Spec
 
-THEOREM RefineObjectProcessingCorrect == Spec => RefineObjectProcessing
+THEOREM OP2_RefineObjectProcessing1 == Spec => RefineObjectProcessing1
 <1>. USE DEF OP1Abs!OBJECT_UNKNOWN, OP1Abs!OBJECT_REGISTERED, OP1Abs!OBJECT_FINALIZED
 <1>1. OP1!Init => OP1Abs!Init
     BY DEF OP1!Init, OP1Abs!Init, objectStateBar
-<1>2. [Next]_vars => [OP1Abs!Next]_(OP1Abs!vars)
-    BY DEF Next, vars, objectStateBar, OP1Abs!Next, OP1Abs!vars, OP1!RegisterObjects,
-        TargetObjects, OP1!UntargetObjects, FinalizeObjects, Terminating,
-        OP1Abs!RegisterObjects, OP1Abs!TargetObjects, OP1Abs!UntargetObjects,
-        OP1Abs!FinalizeObjects, OP1Abs!Terminating, OP1!UnknownObject, UnknownObject,
-        RegisteredObject, FinalizedObject, CompletedObject, AbortedObject,
-        OP1Abs!UnknownObject, OP1Abs!RegisteredObject, OP1Abs!FinalizedObject
-<1>3. [][Next]_vars /\ Fairness => OP1Abs!Fairness
+<1>2. [Next]_vars => [OP1Abs!Next]_OP1Abs!vars
+    <2>. USE DEF objectStateBar
+    <2>1. ASSUME NEW O \in SUBSET Object, OP1!RegisterObjects(O)
+          PROVE OP1Abs!RegisterObjects(O)
+        BY <2>1 DEF OP1!RegisterObjects, OP1Abs!RegisterObjects, OP1!UnknownObject, OP1Abs!UnknownObject
+    <2>2. ASSUME NEW O \in SUBSET Object, TargetObjects(O)
+          PROVE OP1Abs!TargetObjects(O)
+        BY <2>2 DEF TargetObjects, OP1Abs!TargetObjects, RegisteredObject,
+        CompletedObject, AbortedObject, OP1Abs!RegisteredObject, OP1Abs!FinalizedObject
+    <2>3. ASSUME NEW O \in SUBSET Object, OP1!UntargetObjects(O)
+          PROVE OP1Abs!UntargetObjects(O)
+        BY <2>3 DEF OP1!UntargetObjects, OP1Abs!UntargetObjects
+    <2>4. ASSUME NEW O \in SUBSET Object, CompleteObjects(O)
+          PROVE OP1Abs!FinalizeObjects(O)
+        BY <2>4 DEF CompleteObjects, OP1Abs!FinalizeObjects, RegisteredObject,
+        OP1Abs!RegisteredObject
+    <2>5. ASSUME NEW O \in SUBSET Object, AbortObjects(O)
+          PROVE OP1Abs!FinalizeObjects(O)
+        BY <2>5 DEF AbortObjects, OP1Abs!FinalizeObjects, RegisteredObject,
+        OP1Abs!RegisteredObject
+    <2>6. ASSUME NEW O \in SUBSET Object, Terminating
+          PROVE OP1Abs!Terminating
+        BY <2>6 DEF Terminating, OP1Abs!Terminating, vars, OP1Abs!vars,
+        CompletedObject, AbortedObject, OP1Abs!FinalizedObject
+    <2>7. CASE UNCHANGED vars
+        BY <2>7 DEF vars, OP1Abs!vars
+    <2>. QED
+        BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7 DEF Next, OP1Abs!Next
+<1>3. Fairness => OP1Abs!Fairness
     <2>. DEFINE AbsA(o) == o \in objectTargets /\ OP1Abs!FinalizeObjects({o})
-                A(o) == o \in objectTargets /\ FinalizeObjects({o})
-    <2>. SUFFICES ASSUME NEW o \in ObjectId
-                  PROVE [][Next]_vars /\ WF_vars(A(o))
-                            => WF_(OP1Abs!vars)(AbsA(o))
+                A(o)    == o \in objectTargets /\ CompleteObjects({o})
+                B(o)    == o \in objectTargets /\ AbortObjects({o})
+    <2>. SUFFICES ASSUME NEW o \in Object
+                  PROVE WF_vars(A(o)) /\ WF_vars(B(o))
+                        => WF_OP1Abs!vars(AbsA(o))
         BY Isa DEF Fairness, OP1Abs!Fairness
-    <2>1. ENABLED <<AbsA(o)>>_(OP1Abs!vars) => (ENABLED <<A(o)>>_vars)
-        <3>1. (ENABLED <<A(o)>>_vars
-                <=> o \in RegisteredObject /\ o \in objectTargets)
-            <4>1. A(o) => objectState'[o] /= objectState[o]
-              BY DEF RegisteredObject, FinalizeObjects
-            <4>2. <<A(o)>>_vars <=> A(o)
-                BY <4>1 DEF vars
-            <4>3. (ENABLED <<A(o)>>_vars) <=> (ENABLED A(o))
-                BY <4>2, ENABLEDaxioms
-            <4>4. (ENABLED A(o)) <=> o \in RegisteredObject /\ o \in objectTargets
-                BY Isa, ExpandENABLED DEF FinalizeObjects
-            <4>. QED
-                BY <4>3, <4>4
-        <3>2. (ENABLED <<AbsA(o)>>_(OP1Abs!vars)
-                <=> o \in OP1Abs!RegisteredObject /\ o \in objectTargets)
+    <2>1. ENABLED <<AbsA(o)>>_OP1Abs!vars => ENABLED <<A(o)>>_vars /\ ENABLED <<B(o)>>_vars
+        <3>1. ENABLED <<AbsA(o)>>_OP1Abs!vars
+              <=> o \in objectTargets /\ o \in OP1Abs!RegisteredObject
             <4>1. AbsA(o) => objectStateBar' /= objectStateBar
-              BY DEF OP1Abs!FinalizeObjects, OP1Abs!RegisteredObject
+                BY DEF OP1Abs!FinalizeObjects, OP1Abs!RegisteredObject
             <4>2. <<AbsA(o)>>_(OP1Abs!vars) <=> AbsA(o)
                 BY <4>1 DEF OP1Abs!vars
             <4>3. (ENABLED <<AbsA(o)>>_(OP1Abs!vars)) <=> (ENABLED AbsA(o))
                 BY <4>2, ENABLEDaxioms
-            <4>4. (ENABLED AbsA(o))
-                    <=> o \in OP1Abs!RegisteredObject /\ o \in objectTargets
+            <4>4. ENABLED AbsA(o)
+                  <=> o \in OP1Abs!RegisteredObject /\ o \in objectTargets
                 BY ExpandENABLED DEF objectStateBar, OP1Abs!FinalizeObjects
             <4>. QED
                 BY <4>3, <4>4
+        <3>2. ENABLED <<A(o)>>_vars
+              <=> o \in objectTargets /\ o \in RegisteredObject
+            BY ExpandENABLED DEF CompleteObjects, RegisteredObject, vars
+        <3>3. ENABLED <<B(o)>>_vars
+              <=> o \in objectTargets /\ o \in RegisteredObject
+            BY ExpandENABLED DEF AbortObjects, RegisteredObject, vars
         <3>. QED
-            BY <3>1, <3>2 DEF RegisteredObject, OP1Abs!RegisteredObject, objectStateBar
-    <2>2. <<A(o)>>_vars => <<AbsA(o)>>_(OP1Abs!vars)
-        BY DEF vars, objectStateBar, OP1Abs!vars, RegisteredObject, CompletedObject,
-            AbortedObject, FinalizeObjects, OP1Abs!RegisteredObject,
-            OP1Abs!FinalizeObjects
+            BY <3>1, <3>2, <3>3 DEF OP1Abs!RegisteredObject, RegisteredObject,
+            objectStateBar
+    <2>2. <<A(o)>>_vars => <<AbsA(o)>>_OP1Abs!vars
+        BY DEF CompleteObjects, OP1Abs!FinalizeObjects, vars, OP1Abs!vars,
+        RegisteredObject, OP1Abs!RegisteredObject, objectStateBar
+    <2>3. <<B(o)>>_vars => <<AbsA(o)>>_OP1Abs!vars
+        BY DEF AbortObjects, OP1Abs!FinalizeObjects, vars, OP1Abs!vars,
+        RegisteredObject, OP1Abs!RegisteredObject, objectStateBar
     <2>. QED
-        BY <2>1, <2>2, PTL
+        BY <2>1, <2>2, <2>3, PTL
 <1>. QED
-    BY <1>1, <1>2, <1>3, PTL DEF Spec, OP1Abs!Spec, RefineObjectProcessing
+    BY <1>1, <1>2, <1>3, PTL DEF Spec, OP1Abs!Spec, RefineObjectProcessing1
 
 ================================================================================

--- a/specs/ObjectProcessing2_proofs.tla
+++ b/specs/ObjectProcessing2_proofs.tla
@@ -2,7 +2,12 @@
 EXTENDS ObjectProcessing2, TLAPS
 
 USE DEF OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_FINALIZED, OBJECT_COMPLETED,
-OBJECT_ABORTED, OBJECT_DELETED, OP1!OBJECT_UNKNOWN, OP1!OBJECT_REGISTERED, OP1!OBJECT_FINALIZED
+OBJECT_ABORTED, OP1!OBJECT_UNKNOWN, OP1!OBJECT_REGISTERED, OP1!OBJECT_FINALIZED
+
+LEMMA SameAssumptions == OP2Assumptions <=> OP1Abs!OP1Assumptions
+BY DEF IsDenumerableSet, ExistsBijection, Bijection, Injection, Surjection,
+IsInjective, OP1Abs!IsDenumerableSet, OP1Abs!ExistsBijection, OP1Abs!Bijection,
+OP1Abs!Injection, OP1Abs!Surjection, OP1Abs!IsInjective
 
 LEMMA LemType == OP1!Init /\ [][Next]_vars => []TypeOk
 <1>. USE DEF TypeOk, OP2State
@@ -17,6 +22,46 @@ LEMMA LemType == OP1!Init /\ [][Next]_vars => []TypeOk
 
 THEOREM OP2_Type == Spec => []TypeOk
 BY LemType DEF Spec
+
+LEMMA LemRefineObjectProcessing1InitNext == OP1!Init /\ [][Next]_vars
+                                            => OP1Abs!Init /\ [][OP1Abs!Next]_OP1Abs!vars
+<1>. USE DEF OP1Abs!OBJECT_UNKNOWN, OP1Abs!OBJECT_REGISTERED, OP1Abs!OBJECT_FINALIZED
+<1>1. OP1!Init => OP1Abs!Init
+    BY DEF OP1!Init, OP1Abs!Init, objectStateBar
+<1>2. [Next]_vars => [OP1Abs!Next]_OP1Abs!vars
+    <2>. USE DEF objectStateBar
+    <2>1. ASSUME NEW O \in SUBSET Object, OP1!RegisterObjects(O)
+            PROVE OP1Abs!RegisterObjects(O)
+        BY <2>1 DEF OP1!RegisterObjects, OP1Abs!RegisterObjects, OP1!UnknownObject, OP1Abs!UnknownObject
+    <2>2. ASSUME NEW O \in SUBSET Object, TargetObjects(O)
+            PROVE OP1Abs!TargetObjects(O)
+        BY <2>2 DEF TargetObjects, OP1Abs!TargetObjects, RegisteredObject,
+        CompletedObject, AbortedObject, OP1Abs!RegisteredObject, OP1Abs!FinalizedObject
+    <2>3. ASSUME NEW O \in SUBSET Object, OP1!UntargetObjects(O)
+            PROVE OP1Abs!UntargetObjects(O)
+        BY <2>3 DEF OP1!UntargetObjects, OP1Abs!UntargetObjects
+    <2>4. ASSUME NEW O \in SUBSET Object, CompleteObjects(O)
+            PROVE OP1Abs!FinalizeObjects(O)
+        BY <2>4 DEF CompleteObjects, OP1Abs!FinalizeObjects, RegisteredObject,
+        OP1Abs!RegisteredObject
+    <2>5. ASSUME NEW O \in SUBSET Object, AbortObjects(O)
+            PROVE OP1Abs!FinalizeObjects(O)
+        BY <2>5 DEF AbortObjects, OP1Abs!FinalizeObjects, RegisteredObject,
+        OP1Abs!RegisteredObject
+    <2>6. ASSUME NEW O \in SUBSET Object, Terminating
+            PROVE OP1Abs!Terminating
+        BY <2>6 DEF Terminating, OP1Abs!Terminating, vars, OP1Abs!vars,
+        CompletedObject, AbortedObject, OP1Abs!FinalizedObject
+    <2>7. CASE UNCHANGED vars
+        BY <2>7 DEF vars, OP1Abs!vars
+    <2>. QED
+        BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7 DEF Next, OP1Abs!Next
+<1>. QED
+    BY <1>1, <1>2, PTL
+
+LEMMA LemTargetValidity == OP1!Init /\ [][Next]_vars => []OP1Abs!TargetValidity
+BY OP2Assumptions, SameAssumptions, LemRefineObjectProcessing1InitNext,
+OP1Abs!LemTargetValidity
 
 THEOREM OP2_PermanentFinalization == Spec => PermanentFinalization
 <1>. SUFFICES ASSUME NEW o \in Object
@@ -34,77 +79,46 @@ THEOREM OP2_PermanentFinalization == Spec => PermanentFinalization
     BY <1>1, <1>2, PTL DEF Spec
 
 THEOREM OP2_RefineObjectProcessing1 == Spec => RefineObjectProcessing1
+<1>. SUFFICES Fairness => OP1Abs!Fairness
+    BY LemRefineObjectProcessing1InitNext DEF Spec, OP1Abs!Spec, RefineObjectProcessing1
 <1>. USE DEF OP1Abs!OBJECT_UNKNOWN, OP1Abs!OBJECT_REGISTERED, OP1Abs!OBJECT_FINALIZED
-<1>1. OP1!Init => OP1Abs!Init
-    BY DEF OP1!Init, OP1Abs!Init, objectStateBar
-<1>2. [Next]_vars => [OP1Abs!Next]_OP1Abs!vars
-    <2>. USE DEF objectStateBar
-    <2>1. ASSUME NEW O \in SUBSET Object, OP1!RegisterObjects(O)
-          PROVE OP1Abs!RegisterObjects(O)
-        BY <2>1 DEF OP1!RegisterObjects, OP1Abs!RegisterObjects, OP1!UnknownObject, OP1Abs!UnknownObject
-    <2>2. ASSUME NEW O \in SUBSET Object, TargetObjects(O)
-          PROVE OP1Abs!TargetObjects(O)
-        BY <2>2 DEF TargetObjects, OP1Abs!TargetObjects, RegisteredObject,
-        CompletedObject, AbortedObject, OP1Abs!RegisteredObject, OP1Abs!FinalizedObject
-    <2>3. ASSUME NEW O \in SUBSET Object, OP1!UntargetObjects(O)
-          PROVE OP1Abs!UntargetObjects(O)
-        BY <2>3 DEF OP1!UntargetObjects, OP1Abs!UntargetObjects
-    <2>4. ASSUME NEW O \in SUBSET Object, CompleteObjects(O)
-          PROVE OP1Abs!FinalizeObjects(O)
-        BY <2>4 DEF CompleteObjects, OP1Abs!FinalizeObjects, RegisteredObject,
-        OP1Abs!RegisteredObject
-    <2>5. ASSUME NEW O \in SUBSET Object, AbortObjects(O)
-          PROVE OP1Abs!FinalizeObjects(O)
-        BY <2>5 DEF AbortObjects, OP1Abs!FinalizeObjects, RegisteredObject,
-        OP1Abs!RegisteredObject
-    <2>6. ASSUME NEW O \in SUBSET Object, Terminating
-          PROVE OP1Abs!Terminating
-        BY <2>6 DEF Terminating, OP1Abs!Terminating, vars, OP1Abs!vars,
-        CompletedObject, AbortedObject, OP1Abs!FinalizedObject
-    <2>7. CASE UNCHANGED vars
-        BY <2>7 DEF vars, OP1Abs!vars
-    <2>. QED
-        BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7 DEF Next, OP1Abs!Next
-<1>3. Fairness => OP1Abs!Fairness
-    <2>. DEFINE AbsA(o) == o \in objectTargets /\ OP1Abs!FinalizeObjects({o})
-                A(o)    == o \in objectTargets /\ CompleteObjects({o})
-                B(o)    == o \in objectTargets /\ AbortObjects({o})
-    <2>. SUFFICES ASSUME NEW o \in Object
-                  PROVE WF_vars(A(o)) /\ WF_vars(B(o))
-                        => WF_OP1Abs!vars(AbsA(o))
-        BY Isa DEF Fairness, OP1Abs!Fairness
-    <2>1. ENABLED <<AbsA(o)>>_OP1Abs!vars => ENABLED <<A(o)>>_vars /\ ENABLED <<B(o)>>_vars
-        <3>1. ENABLED <<AbsA(o)>>_OP1Abs!vars
-              <=> o \in objectTargets /\ o \in OP1Abs!RegisteredObject
-            <4>1. AbsA(o) => objectStateBar' /= objectStateBar
-                BY DEF OP1Abs!FinalizeObjects, OP1Abs!RegisteredObject
-            <4>2. <<AbsA(o)>>_(OP1Abs!vars) <=> AbsA(o)
-                BY <4>1 DEF OP1Abs!vars
-            <4>3. (ENABLED <<AbsA(o)>>_(OP1Abs!vars)) <=> (ENABLED AbsA(o))
-                BY <4>2, ENABLEDaxioms
-            <4>4. ENABLED AbsA(o)
-                  <=> o \in OP1Abs!RegisteredObject /\ o \in objectTargets
-                BY ExpandENABLED DEF objectStateBar, OP1Abs!FinalizeObjects
-            <4>. QED
-                BY <4>3, <4>4
-        <3>2. ENABLED <<A(o)>>_vars
-              <=> o \in objectTargets /\ o \in RegisteredObject
-            BY ExpandENABLED DEF CompleteObjects, RegisteredObject, vars
-        <3>3. ENABLED <<B(o)>>_vars
-              <=> o \in objectTargets /\ o \in RegisteredObject
-            BY ExpandENABLED DEF AbortObjects, RegisteredObject, vars
+<1>. DEFINE AbsA(o) == o \in objectTargets /\ OP1Abs!FinalizeObjects({o})
+            A(o)    == o \in objectTargets /\ CompleteObjects({o})
+            B(o)    == o \in objectTargets /\ AbortObjects({o})
+<1>. SUFFICES ASSUME NEW o \in Object
+                PROVE WF_vars(A(o)) /\ WF_vars(B(o))
+                    => WF_OP1Abs!vars(AbsA(o))
+    BY Isa DEF Fairness, OP1Abs!Fairness
+<1>1. ENABLED <<AbsA(o)>>_OP1Abs!vars => ENABLED <<A(o)>>_vars /\ ENABLED <<B(o)>>_vars
+    <2>1. ENABLED <<AbsA(o)>>_OP1Abs!vars
+            <=> o \in objectTargets /\ o \in OP1Abs!RegisteredObject
+        <3>1. AbsA(o) => objectStateBar' /= objectStateBar
+            BY DEF OP1Abs!FinalizeObjects, OP1Abs!RegisteredObject
+        <3>2. <<AbsA(o)>>_(OP1Abs!vars) <=> AbsA(o)
+            BY <3>1 DEF OP1Abs!vars
+        <3>3. (ENABLED <<AbsA(o)>>_(OP1Abs!vars)) <=> (ENABLED AbsA(o))
+            BY <3>2, ENABLEDaxioms
+        <3>4. ENABLED AbsA(o)
+                <=> o \in OP1Abs!RegisteredObject /\ o \in objectTargets
+            BY ExpandENABLED DEF objectStateBar, OP1Abs!FinalizeObjects
         <3>. QED
-            BY <3>1, <3>2, <3>3 DEF OP1Abs!RegisteredObject, RegisteredObject,
-            objectStateBar
-    <2>2. <<A(o)>>_vars => <<AbsA(o)>>_OP1Abs!vars
-        BY DEF CompleteObjects, OP1Abs!FinalizeObjects, vars, OP1Abs!vars,
-        RegisteredObject, OP1Abs!RegisteredObject, objectStateBar
-    <2>3. <<B(o)>>_vars => <<AbsA(o)>>_OP1Abs!vars
-        BY DEF AbortObjects, OP1Abs!FinalizeObjects, vars, OP1Abs!vars,
-        RegisteredObject, OP1Abs!RegisteredObject, objectStateBar
+            BY <3>3, <3>4
+    <2>2. ENABLED <<A(o)>>_vars
+            <=> o \in objectTargets /\ o \in RegisteredObject
+        BY ExpandENABLED DEF CompleteObjects, RegisteredObject, vars
+    <2>3. ENABLED <<B(o)>>_vars
+            <=> o \in objectTargets /\ o \in RegisteredObject
+        BY ExpandENABLED DEF AbortObjects, RegisteredObject, vars
     <2>. QED
-        BY <2>1, <2>2, <2>3, PTL
+        BY <2>1, <2>2, <2>3 DEF OP1Abs!RegisteredObject, RegisteredObject,
+        objectStateBar
+<1>2. <<A(o)>>_vars => <<AbsA(o)>>_OP1Abs!vars
+    BY DEF CompleteObjects, OP1Abs!FinalizeObjects, vars, OP1Abs!vars,
+    RegisteredObject, OP1Abs!RegisteredObject, objectStateBar
+<1>3. <<B(o)>>_vars => <<AbsA(o)>>_OP1Abs!vars
+    BY DEF AbortObjects, OP1Abs!FinalizeObjects, vars, OP1Abs!vars,
+    RegisteredObject, OP1Abs!RegisteredObject, objectStateBar
 <1>. QED
-    BY <1>1, <1>2, <1>3, PTL DEF Spec, OP1Abs!Spec, RefineObjectProcessing1
+    BY <1>1, <1>2, <1>3, PTL
 
 ================================================================================

--- a/specs/ObjectProcessing3.cfg
+++ b/specs/ObjectProcessing3.cfg
@@ -1,0 +1,14 @@
+CONSTANTS
+    Object = {o, p, q}
+    IsDenumerableSet <- IsFiniteSet
+
+SPECIFICATION
+    Spec
+
+INVARIANTS
+    TypeOk
+    DeletionValidity
+
+PROPERTIES
+    DeletionQuiescence
+    RefineObjectProcessing2

--- a/specs/ObjectProcessing3.cfg
+++ b/specs/ObjectProcessing3.cfg
@@ -8,6 +8,7 @@ SPECIFICATION
 INVARIANTS
     TypeOk
     DeletionValidity
+    RegisteredTargetsUndeleted
 
 PROPERTIES
     DeletionQuiescence

--- a/specs/ObjectProcessing3.tla
+++ b/specs/ObjectProcessing3.tla
@@ -1,0 +1,201 @@
+--------------------------- MODULE ObjectProcessing3 ---------------------------
+(*****************************************************************************)
+(* This module specifies an extended object lifecycle system that refines    *)
+(* the 'ObjectProcessing2' specification. It provides the modeling of the    *)
+(* object deletion mechanism.                                                *)
+(*****************************************************************************)
+
+EXTENDS DenumerableSets
+
+CONSTANTS
+    Object  \* Abstract set of all objects
+
+ASSUMPTION
+    IsDenumerableSet(Object) \* Object is an infinitely countable set
+
+VARIABLES
+    objectState,   \* objectState[o] records the current lifecycle state of object o
+    objectTargets, \* objectTargets is the set of objects currently marked as targets
+    objectDeleted  \* objectDeleted is the set of objects currently delted
+
+vars == << objectState, objectTargets, objectDeleted >>
+
+-------------------------------------------------------------------------------
+
+(**
+ * Imports the definition of the states of objects and sets of objects sharing
+ * the same state.
+ *)
+INSTANCE ObjectStates
+    WITH SetOfObjectsIn <- LAMBDA s : {o \in Object: objectState[o] = s}
+
+(**
+ * Imports ObjectProcessing2 definitions.
+ *)
+OP2 == INSTANCE ObjectProcessing2
+
+(**
+ * TYPE INVARIANT
+ * Claims that all state variables always take values of the expected form.
+ *   - objectState is a function mapping each object to one of the defined states.
+ *   - objectTargets is a subset of valid object identifiers.
+ *   - deletedObject is a subset of valid object identifiers.
+ *)
+TypeOk ==
+    /\ objectState \in [Object -> OP3State]
+    /\ objectTargets \in SUBSET Object
+    /\ objectDeleted \in SUBSET Object
+
+-------------------------------------------------------------------------------
+
+(*****************************************************************************)
+(* SYSTEM INITIAL STATE AND TRANSITIONS                                      *)
+(*****************************************************************************)
+
+(**
+ * INITIAL STATE
+ * Initially, all objects are unknown and none are marked as targets or deleted.
+ *)
+Init ==
+    /\ OP2!OP1!Init
+    /\ objectDeleted = {}
+
+(**
+ * OBJECT REGISTRATION
+ * A new set 'O' of objects is registered in the system, i.e., it is created
+ * with the metadata provided and empty data.
+ *)
+RegisterObjects(O) ==
+    /\ OP2!OP1!RegisterObjects(O)
+    /\ UNCHANGED objectDeleted
+
+(**
+ * OBJECT TARGETING
+ * A set 'O' of existing objects is marked as targeted, meaning that the user
+ * wants these objects to be finalized (completed or aborted).
+ *)
+TargetObjects(O) ==
+    /\ O \intersect objectDeleted = {}
+    /\ OP2!TargetObjects(O)
+    /\ UNCHANGED objectDeleted
+
+(**
+ * OBJECT UNTARGETING
+ * A set 'O' of currently targeted objects is unmarked.
+ *)
+UntargetObjects(O) ==
+    /\ O \intersect objectDeleted = {}
+    /\ OP2!OP1!UntargetObjects(O)
+    /\ UNCHANGED objectDeleted
+
+(**
+ * OBJECT FINALIZATION
+ * A set 'O' of objects is completed, meaning that their data has been
+ * written and will never be modified.
+ *)
+CompleteObjects(O) ==
+    /\ O \intersect objectDeleted = {}
+    /\ OP2!CompleteObjects(O)
+    /\ UNCHANGED objectDeleted
+
+(**
+ * OBJECT FINALIZATION
+ * A set 'O' of objects is aborted, meaning that these objects have been
+ * generated with empty data and no data will never be provided.
+ *)
+AbortObjects(O) ==
+    /\ O \intersect objectDeleted = {}
+    /\ OP2!AbortObjects(O)
+    /\ UNCHANGED objectDeleted
+
+(**
+ * OBJECT FINALIZATION
+ * A set 'O' of objects is deleted, meaning that the system no longer has
+ * knowledge of these objects (metadata and associated data).
+ *)
+DeleteObjects(O) ==
+    /\ O /= {}
+    /\ O \intersect UnknownObject = {}
+    /\ O \intersect objectTargets = {}
+    /\ objectDeleted' = objectDeleted \union O
+    /\ UNCHANGED << objectState, objectTargets >>
+
+(**
+ * TERMINAL STATE
+ * Action representing the terminal state of the system, reached once all
+ * targeted objects have been completed or aborted.
+ *)
+Terminating ==
+    /\ objectTargets \subseteq (CompletedObject \union AbortedObject)
+    /\ UNCHANGED vars
+
+-------------------------------------------------------------------------------
+
+(*****************************************************************************)
+(* FULL SYSTEM SPECIFICATION                                                 *)
+(*****************************************************************************)
+
+(**
+ * NEXT-STATE RELATION
+ * Defines all possible atomic transitions of the system.
+ *)
+Next ==
+    \/ \E O \in SUBSET Object:
+        \/ TargetObjects(O)
+        \/ UntargetObjects(O)
+        \/ RegisterObjects(O)
+        \/ CompleteObjects(O)
+        \/ AbortObjects(O)
+        \/ DeleteObjects(O)
+    \/ Terminating
+
+(**
+ * FAIRNESS CONDITIONS
+ * Ensure that progress is eventually made for actionable objects.
+ *   - A targeted object cannot remain indefinitely registered without being
+ *     eventually finalized (completed or aborted).
+ *)
+Fairness ==
+    \A o \in Object :
+        /\ WF_vars(o \in objectTargets /\ CompleteObjects({o}))
+        /\ WF_vars(o \in objectTargets /\ AbortObjects({o}))
+
+(**
+ * Full system specification.
+ *)
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ Fairness
+
+-------------------------------------------------------------------------------
+
+(*****************************************************************************)
+(* SAFETY AND LIVENESS PROPERTIES                                            *)
+(*****************************************************************************)
+
+(**
+ * SAFETY
+ * An object can only be deleted if it is known to the system.
+ *)
+DeletionValidity ==
+    \A o \in Object:
+        o \in objectDeleted => ~ o \in UnknownObject
+
+(**
+ * SAFETY
+ * Once deleted, the state of an object does not change.
+ *)
+DeletionQuiescence ==
+    [][ \A o \in Object :
+        o \in objectDeleted =>
+            /\ objectState'[o] = objectState[o]
+            /\ o \in objectTargets' <=> o \in objectTargets ]_vars
+
+(**
+ * LIVENESS
+ * This specification refines the ObjectProcessing2 specification.
+ *)
+RefineObjectProcessing2 == OP2!Spec
+
+================================================================================

--- a/specs/ObjectProcessing3.tla
+++ b/specs/ObjectProcessing3.tla
@@ -10,7 +10,7 @@ EXTENDS DenumerableSets
 CONSTANTS
     Object  \* Abstract set of all objects
 
-ASSUMPTION
+ASSUMPTION OP3Assumptions ==
     IsDenumerableSet(Object) \* Object is an infinitely countable set
 
 VARIABLES
@@ -32,7 +32,7 @@ INSTANCE ObjectStates
 (**
  * Imports ObjectProcessing2 definitions.
  *)
-OP2 == INSTANCE ObjectProcessing2
+OP2 == INSTANCE ObjectProcessing2_proofs
 
 (**
  * TYPE INVARIANT
@@ -116,7 +116,7 @@ AbortObjects(O) ==
 DeleteObjects(O) ==
     /\ O /= {}
     /\ O \intersect UnknownObject = {}
-    /\ O \intersect objectTargets = {}
+    /\ O \intersect objectTargets \intersect RegisteredObject = {}
     /\ objectDeleted' = objectDeleted \union O
     /\ UNCHANGED << objectState, objectTargets >>
 
@@ -141,9 +141,9 @@ Terminating ==
  *)
 Next ==
     \/ \E O \in SUBSET Object:
+        \/ RegisterObjects(O)
         \/ TargetObjects(O)
         \/ UntargetObjects(O)
-        \/ RegisterObjects(O)
         \/ CompleteObjects(O)
         \/ AbortObjects(O)
         \/ DeleteObjects(O)
@@ -184,13 +184,23 @@ DeletionValidity ==
 
 (**
  * SAFETY
+ * A targeted registered object cannot be deleted.
+ *)
+RegisteredTargetsUndeleted ==
+    \A o \in Object:
+        o \in RegisteredObject /\ o \in objectTargets => ~ o \in objectDeleted
+
+(**
+ * SAFETY
  * Once deleted, the state of an object does not change.
  *)
 DeletionQuiescence ==
-    [][ \A o \in Object :
-        o \in objectDeleted =>
-            /\ objectState'[o] = objectState[o]
-            /\ o \in objectTargets' <=> o \in objectTargets ]_vars
+    \A o \in Object:
+        [][
+            (o \in objectDeleted => (
+                /\ objectState'[o] = objectState[o]
+                /\ o \in objectTargets' <=> o \in objectTargets))
+        ]_vars
 
 (**
  * LIVENESS

--- a/specs/ObjectProcessing3_proofs.tla
+++ b/specs/ObjectProcessing3_proofs.tla
@@ -1,0 +1,190 @@
+----------------------- MODULE ObjectProcessing3_proofs ------------------------
+EXTENDS ObjectProcessing3, TLAPS
+
+USE DEF OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_COMPLETED, OBJECT_ABORTED,
+OP2!OP1!OBJECT_UNKNOWN, OP2!OP1!OBJECT_REGISTERED, OP2!OP1!OBJECT_COMPLETED,
+OP2!OP1!OBJECT_ABORTED, OP2!OBJECT_REGISTERED, OP2!OBJECT_COMPLETED,
+OP2!OBJECT_ABORTED
+
+LEMMA SameAssumptions == OP3Assumptions <=> OP2!OP2Assumptions
+BY DEF IsDenumerableSet, ExistsBijection, Bijection, Injection, Surjection,
+IsInjective, OP2!IsDenumerableSet, OP2!ExistsBijection, OP2!Bijection,
+OP2!Injection, OP2!Surjection, OP2!IsInjective
+
+LEMMA LemType == Init /\ [][Next]_vars => []TypeOk
+<1>. USE DEF TypeOk, OP3State
+<1>1. Init => TypeOk
+    BY DEF Init, OP2!OP1!Init
+<1>2. TypeOk /\ [Next]_vars => TypeOk'
+    BY DEF Next, vars, RegisterObjects, OP2!OP1!RegisterObjects,
+    OP2!OP1!RegisteredObject, OP2!TargetObjects, OP2!RegisteredObject,
+    OP2!CompletedObject, OP2!AbortedObject, TargetObjects, OP2!OP1!UntargetObjects,
+    UntargetObjects, CompleteObjects, OP2!CompleteObjects, AbortObjects,
+    OP2!AbortObjects, DeleteObjects, Terminating
+<1>. QED
+    BY <1>1, <1>2, PTL
+
+THEOREM OP3_Type == Spec => []TypeOk
+BY LemType DEF Spec
+
+LEMMA LemDeletionValidity == Init /\ [][Next]_vars => []DeletionValidity
+<1>. USE DEF DeletionValidity, UnknownObject
+<1>1. Init => DeletionValidity
+    BY DEF Init
+<1>2. DeletionValidity /\ [Next]_vars => DeletionValidity'
+    BY DEF Next, vars, RegisterObjects, OP2!OP1!RegisterObjects,
+    OP2!OP1!RegisteredObject, OP2!TargetObjects, OP2!RegisteredObject,
+    OP2!CompletedObject, OP2!AbortedObject, TargetObjects, OP2!OP1!UntargetObjects,
+    UntargetObjects, CompleteObjects, OP2!CompleteObjects, AbortObjects,
+    OP2!AbortObjects, DeleteObjects, Terminating
+<1>. QED
+    BY <1>1, <1>2, PTL
+
+THEOREM OP3_DeletionValidity == Spec => []DeletionValidity
+BY LemDeletionValidity DEF Spec
+
+LEMMA LemRefineObjectProcessing2InitNext == Init /\ [][Next]_vars
+                                         => OP2!OP1!Init /\ [][OP2!Next]_OP2!vars
+<1>1. Init => OP2!OP1!Init
+    BY DEF Init
+<1>2. [Next]_vars => [OP2!Next]_OP2!vars
+    BY DEF Next, vars, OP2!Next, OP2!vars, RegisterObjects, TargetObjects,
+    UntargetObjects, CompleteObjects, AbortObjects, DeleteObjects, Terminating,
+    OP2!Terminating
+<1>. QED
+    BY <1>1, <1>2, PTL
+
+LEMMA LemTargetValidity == Init /\ [][Next]_vars => []OP2!OP1Abs!TargetValidity
+BY OP3Assumptions, LemRefineObjectProcessing2InitNext, OP2!LemTargetValidity,
+SameAssumptions
+
+LEMMA LemRegisteredTargetsUndeleted == Init /\ [][Next]_vars => []RegisteredTargetsUndeleted
+<1>. USE DEF RegisteredTargetsUndeleted, RegisteredObject
+<1>1. Init => RegisteredTargetsUndeleted
+    BY DEF Init
+<1>2. OP2!OP1Abs!TargetValidity /\ RegisteredTargetsUndeleted /\ [Next]_vars => RegisteredTargetsUndeleted'
+    <2>. SUFFICES ASSUME OP2!OP1Abs!TargetValidity, RegisteredTargetsUndeleted, [Next]_vars
+                  PROVE RegisteredTargetsUndeleted'
+        OBVIOUS
+    <2>1. ASSUME NEW O \in SUBSET Object, RegisterObjects(O)
+          PROVE RegisteredTargetsUndeleted'
+        BY <2>1 DEF OP2!OP1Abs!TargetValidity, RegisterObjects,
+        OP2!OP1!RegisterObjects, OP2!OP1!UnknownObject,
+        OP2!OP1Abs!UnknownObject, OP2!objectStateBar,
+        OP2!OP1Abs!OBJECT_UNKNOWN
+    <2>2. ASSUME NEW O \in SUBSET Object, TargetObjects(O)
+          PROVE RegisteredTargetsUndeleted'
+        BY <2>2 DEF TargetObjects, OP2!TargetObjects
+    <2>3. ASSUME NEW O \in SUBSET Object, UntargetObjects(O)
+          PROVE RegisteredTargetsUndeleted'
+        BY <2>3 DEF UntargetObjects, OP2!OP1!UntargetObjects
+    <2>4. ASSUME NEW O \in SUBSET Object, CompleteObjects(O)
+          PROVE RegisteredTargetsUndeleted'
+        BY <2>4 DEF CompleteObjects, OP2!CompleteObjects
+    <2>5. ASSUME NEW O \in SUBSET Object, AbortObjects(O)
+          PROVE RegisteredTargetsUndeleted'
+        BY <2>5 DEF AbortObjects, OP2!AbortObjects
+    <2>6. ASSUME NEW O \in SUBSET Object, DeleteObjects(O)
+          PROVE RegisteredTargetsUndeleted'
+        BY <2>6 DEF DeleteObjects
+    <2>7. CASE Terminating
+        BY <2>7 DEF Terminating, vars
+    <2>8. CASE UNCHANGED vars
+        BY <2>8 DEF vars
+    <2>. QED
+        BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8 DEF Next
+<1>. QED
+    BY <1>1, <1>2, LemTargetValidity, PTL
+
+THEOREM OP3_RegisteredTargetsUndeleted == Spec => []RegisteredTargetsUndeleted
+BY LemRegisteredTargetsUndeleted DEF Spec
+
+ObjectSafetyInv ==
+    /\ TypeOk
+    /\ OP2!OP1Abs!TargetValidity
+    /\ DeletionValidity
+    /\ RegisteredTargetsUndeleted
+
+LEMMA LemObjectSafetyInv == Init /\ [][Next]_vars => []ObjectSafetyInv
+BY LemType, LemDeletionValidity, LemRegisteredTargetsUndeleted,
+LemTargetValidity, PTL DEF ObjectSafetyInv
+
+THEOREM OP3_ObjectSafetyInv == Spec => []ObjectSafetyInv
+BY LemObjectSafetyInv DEF Spec
+
+THEOREM OP3_DeletionQuiescence == Spec => DeletionQuiescence
+<1>. SUFFICES ASSUME NEW o \in Object
+              PROVE Spec => [][o \in objectDeleted =>
+                                    /\ objectState'[o] = objectState[o]
+                                    /\ o \in objectTargets' <=> o \in objectTargets]_vars
+    BY DEF DeletionQuiescence
+<1>1. ObjectSafetyInv /\ o \in objectDeleted /\ [Next]_vars => /\ objectState'[o] = objectState[o]
+                                                               /\ o \in objectTargets' <=> o \in objectTargets
+    BY DEF ObjectSafetyInv, DeletionValidity, Next, vars, RegisterObjects,
+    OP2!OP1!RegisterObjects, TargetObjects, OP2!TargetObjects, UntargetObjects,
+    OP2!OP1!UntargetObjects, CompleteObjects, OP2!CompleteObjects, AbortObjects,
+    OP2!AbortObjects, DeleteObjects, Terminating, UnknownObject, RegisteredObject,
+    CompletedObject, AbortedObject, OP2!OP1!UnknownObject
+<1>. QED
+    BY <1>1, OP3_ObjectSafetyInv, PTL DEF Spec
+
+THEOREM OP3_RefineObjectProcessing2 == Spec => RefineObjectProcessing2
+<1>. SUFFICES []ObjectSafetyInv /\ Fairness => OP2!Fairness
+    BY LemRefineObjectProcessing2InitNext, OP3_ObjectSafetyInv DEF Spec, OP2!Spec, RefineObjectProcessing2
+<1>. SUFFICES ASSUME NEW o \in Object
+                PROVE /\ /\ []ObjectSafetyInv
+                        /\ WF_vars(o \in objectTargets /\ CompleteObjects({o}))
+                        => WF_OP2!vars(o \in objectTargets /\ OP2!CompleteObjects({o}))
+                    /\ /\ []ObjectSafetyInv
+                        /\ WF_vars(o \in objectTargets /\ AbortObjects({o}))
+                        => WF_OP2!vars(o \in objectTargets /\ OP2!AbortObjects({o}))
+    BY Isa DEF Fairness, OP2!Fairness
+<1>1. []ObjectSafetyInv /\ WF_vars(o \in objectTargets /\ CompleteObjects({o}))
+        => WF_OP2!vars(o \in objectTargets /\ OP2!CompleteObjects({o}))
+    <2>. DEFINE AbsA(o) == o \in objectTargets /\ OP2!CompleteObjects({o})
+                A(o)    == o \in objectTargets /\ CompleteObjects({o})
+                P       == ~ o \in objectDeleted
+    <2>0. ENABLED <<AbsA(o)>>_OP2!vars
+            => o \in objectTargets /\ o \in OP2!RegisteredObject
+        BY ExpandENABLED DEF OP2!CompleteObjects, OP2!vars
+    <2>1. P /\ ENABLED <<AbsA(o)>>_OP2!vars => ENABLED <<A(o)>>_vars
+        <4>1. ENABLED <<A(o)>>_vars
+                <=> o \in objectTargets /\ o \in OP2!RegisteredObject /\ ~ o \in objectDeleted
+            BY ExpandENABLED DEF CompleteObjects, OP2!CompleteObjects, vars,
+            OP2!RegisteredObject
+        <4>. QED
+            BY <2>0, <4>1
+    <2>2. <<A(o)>>_vars => <<AbsA(o)>>_OP2!vars
+        BY DEF CompleteObjects, vars, OP2!vars
+    <2>3. ObjectSafetyInv /\ ENABLED <<AbsA(o)>>_OP2!vars => P
+        BY <2>0 DEF ObjectSafetyInv, RegisteredTargetsUndeleted, RegisteredObject,
+        OP2!RegisteredObject
+    <2>. QED
+        BY <2>1, <2>2, <2>3, PTL
+<1>2. []ObjectSafetyInv /\ WF_vars(o \in objectTargets /\ AbortObjects({o}))
+        => WF_OP2!vars(o \in objectTargets /\ OP2!AbortObjects({o}))
+    <2>. DEFINE AbsA(o) == o \in objectTargets /\ OP2!AbortObjects({o})
+                A(o)    == o \in objectTargets /\ AbortObjects({o})
+                P       == ~ o \in objectDeleted
+    <2>0. ENABLED <<AbsA(o)>>_OP2!vars
+            => o \in objectTargets /\ o \in OP2!RegisteredObject
+        BY ExpandENABLED DEF OP2!AbortObjects, OP2!vars
+    <2>1. P /\ ENABLED <<AbsA(o)>>_OP2!vars => ENABLED <<A(o)>>_vars
+        <4>1. ENABLED <<A(o)>>_vars
+                <=> o \in objectTargets /\ o \in OP2!RegisteredObject /\ ~ o \in objectDeleted
+            BY ExpandENABLED DEF AbortObjects, OP2!AbortObjects, vars,
+            OP2!RegisteredObject
+        <4>. QED
+            BY <2>0, <4>1
+    <2>2. <<o \in objectTargets /\ AbortObjects({o})>>_vars
+            => <<o \in objectTargets /\ OP2!AbortObjects({o})>>_OP2!vars
+        BY DEF AbortObjects, vars, OP2!vars
+    <2>3. ObjectSafetyInv /\ ENABLED <<AbsA(o)>>_OP2!vars => P
+        BY <2>0 DEF ObjectSafetyInv, RegisteredTargetsUndeleted, RegisteredObject,
+        OP2!RegisteredObject
+    <2>. QED
+        BY <2>1, <2>2, <2>3, PTL
+<1>. QED
+    BY <1>1, <1>2, Isa
+
+================================================================================

--- a/specs/ObjectStates.tla
+++ b/specs/ObjectStates.tla
@@ -24,8 +24,6 @@ OBJECT_REGISTERED == "OBJECT_REGISTERED" \* Object created with only its metadat
 OBJECT_FINALIZED  == "OBJECT_FINALIZED"  \* Object has been successfully generated
 OBJECT_COMPLETED  == "OBJECT_COMPLETED"  \* Object has been generated with a non-empty data
 OBJECT_ABORTED    == "OBJECT_ABORTED"    \* Object has been genereted without any data
-OBJECT_DELETED    == "OBJECT_DELETED"    \* Object has been deleted from the system
-
 
 (**
  * Sets of states accessible for each level of refinement.
@@ -34,7 +32,7 @@ OP1State == {OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_FINALIZED}
 OP2State == {OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_COMPLETED,
              OBJECT_ABORTED}
 OP3State == {OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_COMPLETED,
-             OBJECT_ABORTED, OBJECT_DELETED}
+             OBJECT_ABORTED}
 
 (**
  * Sets of objects by state.
@@ -44,6 +42,5 @@ RegisteredObject == SetOfObjectsIn(OBJECT_REGISTERED)
 FinalizedObject  == SetOfObjectsIn(OBJECT_FINALIZED)
 CompletedObject  == SetOfObjectsIn(OBJECT_COMPLETED)
 AbortedObject    == SetOfObjectsIn(OBJECT_ABORTED)
-DeletedObject    == SetOfObjectsIn(OBJECT_DELETED)
 
 ===============================================================================

--- a/specs/ObjectStates.tla
+++ b/specs/ObjectStates.tla
@@ -8,9 +8,6 @@
 (* allowing other specifications to reason about groups of objects sharing   *)
 (* the same lifecycle phase.                                                 *)
 (*****************************************************************************)
-EXTENDS Utils
-
-LOCAL INSTANCE FiniteSets
 
 (**
  * Abstract operator returning the set of objects in a given state.
@@ -20,34 +17,24 @@ CONSTANT
                       \* state variables.
 
 (**
- * Object states in their lifecycle.
+ * Object lifecycle states.
  *)
-OBJECT_UNKNOWN == "OBJECT_UNKNOWN"       \* Object is virtual, not yet known to the system
+OBJECT_UNKNOWN    == "OBJECT_UNKNOWN"       \* Object is virtual, not yet known to the system
 OBJECT_REGISTERED == "OBJECT_REGISTERED" \* Object created with only its metadata and empty data.
 OBJECT_FINALIZED  == "OBJECT_FINALIZED"  \* Object has been successfully generated
 OBJECT_COMPLETED  == "OBJECT_COMPLETED"  \* Object has been generated with a non-empty data
 OBJECT_ABORTED    == "OBJECT_ABORTED"    \* Object has been genereted without any data
 OBJECT_DELETED    == "OBJECT_DELETED"    \* Object has been deleted from the system
 
-(**
- * Set of all object states.
- *)
-ObjectState ==
-    {
-        OBJECT_UNKNOWN,
-        OBJECT_REGISTERED,
-        OBJECT_FINALIZED,
-        OBJECT_COMPLETED,
-        OBJECT_ABORTED,
-        OBJECT_DELETED
-    }
 
 (**
- * SetOfObjectsIn must return a finite set for each object state.
+ * Sets of states accessible for each level of refinement.
  *)
-ASSUME
-    \A s \in ObjectState:
-        IsFiniteSet(SetOfObjectsIn(s))
+OP1State == {OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_FINALIZED}
+OP2State == {OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_COMPLETED,
+             OBJECT_ABORTED}
+OP3State == {OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_COMPLETED,
+             OBJECT_ABORTED, OBJECT_DELETED}
 
 (**
  * Sets of objects by state.
@@ -58,26 +45,5 @@ FinalizedObject  == SetOfObjectsIn(OBJECT_FINALIZED)
 CompletedObject  == SetOfObjectsIn(OBJECT_COMPLETED)
 AbortedObject    == SetOfObjectsIn(OBJECT_ABORTED)
 DeletedObject    == SetOfObjectsIn(OBJECT_DELETED)
-
-
-(**
- * SAFETY PROPERTY
- * Asserts that the sets representing different object lifecycle stages are 
- * mutually disjoint. This ensures that every object exists in exactly one 
- * primary state at any given time, preventing logical overlaps (e.g., an 
- * object being both 'Completed' and 'Deleted').
- *
- * Any specification instantiating the current module must have this property
- * as an invariant.
- *)
-DistinctObjectStates ==
-    IsPairwiseDisjoint({
-        UnknownObject,
-        RegisteredObject,
-        FinalizedObject,
-        CompletedObject,
-        AbortedObject,
-        DeletedObject
-    })
 
 ===============================================================================


### PR DESCRIPTION
- **chore: update naming and documentation of ObjectProcessing1 and ObjectProcessing2 specifications**
- **feat: add ObjectProcessing3 specification**
- **fix: fix ObjectProcessing1 and ObjectProcess2 proofs following the update of the two specifications**
- **feat: add proofs for ObjectProcessing3 specification**
