### PR TITLE
feat: Remove Agent abstraction from task and graph processing specs

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,185 @@
+modules:
+
+  - path: specs/TaskProcessing1.tla
+    dependencies:
+      community_modules: true
+    models:
+      - name: small
+        checks:
+          success: true
+          total_states: 1123
+          distinct_states: 216
+          state_depth: 6
+
+  - path: specs/TaskProcessing1_proofs.tla
+    dependencies:
+      community_modules: true
+    proofs:
+      - name: all
+        checks:
+          success: true
+          num_obligations: 78
+          num_omitted: 0
+          num_unproved: 0
+
+  - path: specs/TaskProcessing2_mc.tla
+    dependencies:
+      community_modules: true
+      tlaps_stdlib: true
+    models:
+      - name: small
+        settings:
+          workers: auto
+        checks:
+          success: true
+          total_states: 285
+          distinct_states: 98
+          state_depth: 12
+
+  - path: specs/TaskProcessing3_mc.tla
+    dependencies:
+      community_modules: true
+      tlaps_stdlib: true
+    models:
+      - name: small
+        settings:
+          workers: auto
+        checks:
+          success: true
+          total_states: 18842
+          distinct_states: 1793
+          state_depth: 14
+
+  - path: specs/TaskProcessing4_mc.tla
+    dependencies:
+      community_modules: true
+      tlaps_stdlib: true
+    models:
+      - name: small
+        settings:
+          workers: auto
+        checks:
+          success: true
+          total_states: 25106
+          distinct_states: 2697
+          state_depth: 15
+
+  - path: specs/ObjectProcessing1.tla
+    dependencies:
+      community_modules: true
+    models:
+      - name: small
+        checks:
+          success: true
+          total_states: 1196
+          distinct_states: 125
+          state_depth: 4
+
+  - path: specs/ObjectProcessing1_proofs.tla
+    dependencies:
+      community_modules: true
+    proofs:
+      - name: all
+        checks:
+          success: true
+          num_obligations: 61
+          num_omitted: 0
+          num_unproved: 0
+
+  - path: specs/ObjectProcessing2.tla
+    dependencies:
+      community_modules: true
+      tlaps_stdlib: true
+    models:
+      - name: small
+        checks:
+          success: true
+          total_states: 3669
+          distinct_states: 343
+          state_depth: 5
+
+  - path: specs/ObjectProcessing2_proofs.tla
+    dependencies:
+      community_modules: true
+      tlaps_stdlib: true
+    proofs:
+      - name: all
+        checks:
+          success: true
+          num_obligations: 80
+          num_omitted: 0
+          num_unproved: 0
+
+  - path: specs/ObjectProcessing3.tla
+    dependencies:
+      community_modules: true
+      tlaps_stdlib: true
+    models:
+      - name: small
+        checks:
+          success: true
+          total_states: 18504
+          distinct_states: 1728
+          state_depth: 6
+
+  - path: specs/ObjectProcessing3_proofs.tla
+    dependencies:
+      community_modules: true
+      tlaps_stdlib: true
+    proofs:
+      - name: all
+        checks:
+          success: true
+          num_obligations: 154
+          num_omitted: 0
+          num_unproved: 0
+
+  - path: specs/SessionProcessing1.tla
+    models:
+      - name: small
+        checks:
+          success: true
+          total_states: 2232
+          distinct_states: 343
+          state_depth: 7
+
+  - path: specs/SessionProcessing1_proofs.tla
+    proofs:
+      - name: all
+        checks:
+          success: true
+          num_obligations: 26
+          num_omitted: 0
+          num_unproved: 0
+
+  - path: specs/GraphProcessing1_mc.tla
+    dependencies:
+      community_modules: true
+      tlaps_stdlib: true
+      external_modules:
+        - modules/dist/ArmoniKSpecModules-deps.jar
+    models:
+      - name: small
+        settings:
+          worker: auto
+        checks:
+          success: true
+          total_states: 4444
+          distinct_states: 609
+          state_depth: 10
+
+  - path: specs/GraphProcessing2_mc.tla
+    dependencies:
+      community_modules: true
+      tlaps_stdlib: true
+      external_modules:
+        - modules/dist/ArmoniKSpecModules-deps.jar
+    models:
+      - name: small
+        settings:
+          worker: auto
+        checks:
+          success: true
+          total_states: 824
+          distinct_states: 137
+          state_depth: 9

--- a/specs/GraphProcessing1.tla
+++ b/specs/GraphProcessing1.tla
@@ -5,7 +5,7 @@
 (*                                                                           *)
 (*   - Tasks produce and consume data objects.                               *)
 (*   - Task and object dependencies form a directed acyclic bipartite graph. *)
-(*   - Agents (workers) dynamically process tasks.                           *)
+(*   - Tasks are dynamically processed.                                      *)
 (*   - Tasks and objects may be dynamically registred over time.             *)
 (*                                                                           *)
 (* The specification defines the allowable transitions of the system,        *)
@@ -15,26 +15,21 @@
 EXTENDS DenumerableSets, FiniteSetTheorems, Graphs, Naturals, Sequences
 
 CONSTANTS
-    Agent,   \* Set of agent identifiers (theoretically infinite)
     Object,  \* Set of object identifiers (theoretically infinite)
     Task     \* Set of task identifiers (theoretically infinite)
 
 ASSUMPTION GP1Assumptions ==
-    /\ Agent \intersect Object = {}
-    /\ Agent \intersect Task = {}
     /\ Object \intersect Task = {}
-    /\ IsFiniteSet(Agent)
     /\ IsDenumerableSet(Object)
     /\ IsDenumerableSet(Task)
 
 VARIABLES
-    agentTaskAlloc, \* agentTaskAlloc[a] is the set of tasks currently assigned to agent a
     deps,           \* deps is the directed dependency graph over task and object identifiers
     objectState,    \* objectState[o] records the current lifecycle state of object o
     objectTargets,  \* objectTargets is the set of objects currently marked as targets
     taskState       \* taskState[t] records the current lifecycle state of task t
 
-vars == << agentTaskAlloc, deps, objectState, objectTargets, taskState >>
+vars == << deps, objectState, objectTargets, taskState >>
 
 -------------------------------------------------------------------------------
 
@@ -67,7 +62,6 @@ OP1 == INSTANCE ObjectProcessing1
 (**
  * TYPE INVARIANT
  * Claims that all state variables always take values of the expected form.
- *   - Each agent is associated with a subset of tasks.
  *   - Each object has one of the defined object lifecycle states.
  *   - Targeted objects are valid object identifiers.
  *   - Each task has one of the defined task lifecycle states.
@@ -76,7 +70,6 @@ OP1 == INSTANCE ObjectProcessing1
  *     as fields).
  *)
 TypeOk ==
-    /\ agentTaskAlloc \in [Agent -> SUBSET Task]
     /\ taskState \in [Task -> TP1State]
     /\ objectState \in [Object -> OP1State]
     /\ objectTargets \in SUBSET Object
@@ -134,7 +127,6 @@ MandatorySuccessors(G, t) ==
  * Initially, no tasks, objects, or dependencies exist.
  *)
 Init ==
-    /\ agentTaskAlloc = [a \in Agent |-> {}]
     /\ taskState = [t \in Task |-> TASK_UNKNOWN]
     /\ objectState = [o \in Object |-> OBJECT_UNKNOWN]
     /\ objectTargets = {}
@@ -168,7 +160,7 @@ RegisterGraph(G) ==
                 IF t \in G.node
                     THEN TASK_REGISTERED
                     ELSE taskState[t]]
-        /\ UNCHANGED << agentTaskAlloc, objectTargets >>
+        /\ UNCHANGED objectTargets
 
 (**
  * OBJECT TARGETING
@@ -178,7 +170,7 @@ RegisterGraph(G) ==
 TargetObjects(O) ==
     /\ O /= {} /\ O \subseteq (RegisteredObject \union FinalizedObject)
     /\ objectTargets' = objectTargets \union O
-    /\ UNCHANGED << agentTaskAlloc, deps, objectState, taskState >>
+    /\ UNCHANGED << deps, objectState, taskState >>
 
 (**
  * OBJECT UNTARGETING
@@ -187,7 +179,7 @@ TargetObjects(O) ==
 UntargetObjects(O) ==
     /\ O /= {} /\ O \subseteq objectTargets
     /\ objectTargets' = objectTargets \ O
-    /\ UNCHANGED << agentTaskAlloc, deps, objectState, taskState >>
+    /\ UNCHANGED << deps, objectState, taskState >>
 
 (**
  * OBJECT FINALIZATION
@@ -201,7 +193,7 @@ FinalizeObjects(O) ==
        \/ \A o \in O: \E t \in Predecessors(deps, o): t \in ProcessedTask
     /\ objectState' =
         [o \in Object |-> IF o \in O THEN OBJECT_FINALIZED ELSE objectState[o]]
-    /\ UNCHANGED << agentTaskAlloc, deps, objectTargets, taskState >>
+    /\ UNCHANGED << deps, objectTargets, taskState >>
 
 (**
  * TASK STAGING
@@ -213,50 +205,46 @@ StageTasks(T) ==
     /\ T /= {} /\ T \subseteq RegisteredTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_STAGED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, deps, objectState, objectTargets >>
+    /\ UNCHANGED << deps, objectState, objectTargets >>
 
 (**
  * TASK BYPASS
  * A set 'T' of registered or staged tasks is moved directly to the processed
- * state, bypassing agent assignment and execution.
+ * state, bypassing assignment and execution.
  *)
 DiscardTasks(T) ==
     /\ T /= {}
     /\ T \subseteq RegisteredTask \union StagedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_PROCESSED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, deps, objectState, objectTargets >>
+    /\ UNCHANGED << deps, objectState, objectTargets >>
 
 (**
  * TASK ASSIGNMENT
- * An agent 'a' takes responsibility for processing a set 'T' of staged tasks.
+ * A set 'T' of staged tasks is assigned for processing.
  *)
-AssignTasks(a, T) ==
+AssignTasks(T) ==
     /\ T /= {} /\ T \subseteq StagedTask
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \union T]
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_ASSIGNED ELSE taskState[t]]
     /\ UNCHANGED << deps, objectState, objectTargets >>
 
 (**
  * TASK RELEASE
- * An agent 'a' postpones a set 'T' of tasks it currently holds.
+ * A set 'T' of assigned tasks is released back to the staged pool.
  *)
-ReleaseTasks(a, T) ==
-    /\ T /= {} /\ T \subseteq agentTaskAlloc[a]
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
+ReleaseTasks(T) ==
+    /\ T /= {} /\ T \subseteq AssignedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_STAGED ELSE taskState[t]]
     /\ UNCHANGED << deps, objectState, objectTargets >>
 
 (**
  * TASK PROCESSING
- * An agent 'a' completes the processing of a set 'T' of tasks it currently
- * holds.
+ * A set 'T' of assigned tasks completes processing.
  *)
-ProcessTasks(a, T) ==
-    /\ T /= {} /\ T \subseteq agentTaskAlloc[a]
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
+ProcessTasks(T) ==
+    /\ T /= {} /\ T \subseteq AssignedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_PROCESSED ELSE taskState[t]]
     /\ UNCHANGED << deps, objectState, objectTargets >>
@@ -276,7 +264,7 @@ FinalizeTasks(T) ==
             => \E t \in (Predecessors(deps, o) \ T) : t \notin FinalizedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_FINALIZED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, deps, objectState, objectTargets >>
+    /\ UNCHANGED << deps, objectState, objectTargets >>
 
 (**
  * TERMINAL STATE
@@ -308,10 +296,9 @@ Next ==
     \/ \E T \in SUBSET Task:
         \/ StageTasks(T)
         \/ DiscardTasks(T)
-        \/ \E a \in Agent:
-            \/ AssignTasks(a, T)
-            \/ ReleaseTasks(a, T)
-            \/ ProcessTasks(a, T)
+        \/ AssignTasks(T)
+        \/ ReleaseTasks(T)
+        \/ ProcessTasks(T)
         \/ FinalizeTasks(T)
     \/ Terminating
 
@@ -370,8 +357,8 @@ IsTaskUpstreamOnOpenPathToTarget(t, o) ==
  *   - Every object that becomes eligible for finalization is eventually finalized.
  *   - Every registered task whose input objects are finalized is eventually staged.
  *   - Every task that lies upstream on an open path toward some unfinalized
- *     target object is eventually assigned to an agent.
- *   - Every assigned task is eventually processed by some agent.
+ *     target object is eventually assigned.
+ *   - Every assigned task is eventually processed.
  *   - Every processed task whose outputs become eligible for finalization is
  *     eventually finalized.
  *)
@@ -382,8 +369,8 @@ Fairness ==
         /\ WF_vars(StageTasks({t}))
         /\ WF_vars(
             /\ \E o \in Object : IsTaskUpstreamOnOpenPathToTarget(t, o)
-            /\ \E a \in Agent : AssignTasks(a, {t}))
-        /\ SF_vars(\E a \in Agent : ProcessTasks(a, {t}))
+            /\ AssignTasks({t}))
+        /\ SF_vars(ProcessTasks({t}))
         /\ WF_vars(FinalizeTasks({t}))
 
 (**
@@ -458,11 +445,6 @@ FinalizedSourcesInvariant ==
  * SAFETY
  * The data dependencies of each task remain immutable throughout execution.
  *)
-\* TaskDataDependenciesInvariant ==
-\*     \A t \in Task:
-\*         [][ t \notin UnknownTask => 
-\*                 /\ Predecessors(deps, t) = Predecessors(deps', t)
-\*                 /\ Successors(deps, t) = Successors(deps', t) ]_deps
 TaskDataDependenciesInvariant ==
     \A t \in Task:
         [](t \notin UnknownTask =>

--- a/specs/GraphProcessing1_mc.cfg
+++ b/specs/GraphProcessing1_mc.cfg
@@ -1,5 +1,4 @@
 CONSTANTS
-    Agent = {a, b}
     Object = {o, p}
     Task = {t, u}
     Graphs <- MCGraphs

--- a/specs/GraphProcessing1_mc.tla
+++ b/specs/GraphProcessing1_mc.tla
@@ -2,10 +2,10 @@
 (*******************************************************************************)
 (* Bounded model-checking extension of GraphProcessing.                        *)
 (*                                                                             *)
-(* For model checking, the sets of task, objects and agent identifiers  must   *)
-(* be finite and explicitly materialized. Since the number of tasks and        *)
-(* objects are finite, the system eventually reaches a state where no new      *)
-(* graph can be registered, which leads to an artificial deadlock.             *)
+(* For model checking, the sets of task and object identifiers must be finite  *)
+(* and explicitly materialized. Since the number of tasks and objects are       *)
+(* finite, the system eventually reaches a state where no new graph can be     *)
+(* registered, which leads to an artificial deadlock.                           *)
 (*                                                                             *)
 (* To avoid this spurious deadlock, the next-state action is overridden to     *)
 (* include a dummy terminal state, allowing the model checker to terminate     *)
@@ -39,9 +39,9 @@ MCSpec ==
 --------------------------------------------------------------------------------
 
 (**
- * Symmetry relation between task, object and agent identifiers.
+ * Symmetry relation between task and object identifiers.
  *)
 Symmetry ==
-    Permutations(Task) \union Permutations(Object) \union Permutations(Agent)
+    Permutations(Task) \union Permutations(Object)
 
 ================================================================================

--- a/specs/GraphProcessing2.tla
+++ b/specs/GraphProcessing2.tla
@@ -3,31 +3,26 @@
 EXTENDS DenumerableSets, FiniteSets, Graphs, Naturals, Sequences, Utils, TLC
 
 CONSTANTS
-    Agent,    \* Set of agent identifiers
     Object,   \* Set of object identifiers
     Task,     \* Set of task identifiers
     MaxRetries, \* Maximal number of retries for tasks
     NULL        \* Constant representing a null value
 
 ASSUMPTION GP2Assumptions ==
-    /\ Agent \intersect Object = {}
-    /\ Agent \intersect Task = {}
     /\ Object \intersect Task = {}
-    /\ IsFiniteSet(Agent)
     /\ IsDenumerableSet(Object)
     /\ IsDenumerableSet(Task)
     /\ MaxRetries \in Nat
     /\ NULL \notin Task
 
 VARIABLES
-    agentTaskAlloc,     \* agentTaskAlloc[a]: set of tasks assigned to agent a
     deps,               \* deps: the directed dependency graph over task and object identifiers
     objectState,        \* objectState[o]: current lifecycle state of object o
     objectTargets,      \* objectTargets: set of objects currently marked as targets
     taskState,         \* taskState[t]: current lifecycle state of task t
     nextAttemptOf
 
-vars == << agentTaskAlloc, deps, objectState, objectTargets, taskState, nextAttemptOf >>
+vars == << deps, objectState, objectTargets, taskState, nextAttemptOf >>
 
 -------------------------------------------------------------------------------
 
@@ -48,7 +43,6 @@ GP1 == INSTANCE GraphProcessing1
 -------------------------------------------------------------------------------
 
 TypeOk ==
-    /\ agentTaskAlloc \in [Agent -> SUBSET Task]
     /\ taskState \in [Task -> TP2State]
     /\ nextAttemptOf \in [Task -> Task \union {NULL}]
     /\ objectState \in [Object -> OP2State]
@@ -63,7 +57,6 @@ TypeOk ==
 (*****************************************************************************)
 
 Init ==
-    /\ agentTaskAlloc = [a \in Agent |-> {}]
     /\ taskState = [t \in Task |-> TASK_UNKNOWN]
     /\ nextAttemptOf = [t \in Task |-> NULL]
     /\ objectState = [o \in Object |-> OBJECT_UNKNOWN]
@@ -92,17 +85,17 @@ RegisterGraph(G) ==
                 IF t \in G.node
                     THEN TASK_REGISTERED
                     ELSE taskState[t]]
-        /\ UNCHANGED << agentTaskAlloc, objectTargets, nextAttemptOf >>
+        /\ UNCHANGED << objectTargets, nextAttemptOf >>
 
 TargetObjects(O) ==
     /\ O /= {} /\ O \subseteq UNION {RegisteredObject, CompletedObject, AbortedObject}
     /\ objectTargets' = objectTargets \union O
-    /\ UNCHANGED << agentTaskAlloc, deps, objectState, taskState, nextAttemptOf >>
+    /\ UNCHANGED << deps, objectState, taskState, nextAttemptOf >>
 
 UntargetObjects(O) ==
     /\ O /= {} /\ O \subseteq objectTargets
     /\ objectTargets' = objectTargets \ O
-    /\ UNCHANGED << agentTaskAlloc, deps, objectState, taskState, nextAttemptOf >>
+    /\ UNCHANGED << deps, objectState, taskState, nextAttemptOf >>
 
 CompleteObjects(O) ==
     /\ O /= {} /\ O \subseteq RegisteredObject
@@ -110,7 +103,7 @@ CompleteObjects(O) ==
        \/ \A o \in O: \E t \in Predecessors(deps, o): t \in SucceededTask
     /\ objectState' =
         [o \in Object |-> IF o \in O THEN OBJECT_COMPLETED ELSE objectState[o]]
-    /\ UNCHANGED << agentTaskAlloc, deps, objectTargets, taskState, nextAttemptOf >>
+    /\ UNCHANGED << deps, objectTargets, taskState, nextAttemptOf >>
 
 AbortObjects(O) ==
     /\ O /= {} /\ O \subseteq RegisteredObject
@@ -121,7 +114,7 @@ AbortObjects(O) ==
                 /\ Predecessors(deps, o) \ {t} \subseteq UNION {DiscardedTask, CompletedTask, AbortedTask, RetriedTask}
     /\ objectState' =
         [o \in Object |-> IF o \in O THEN OBJECT_ABORTED ELSE objectState[o]]
-    /\ UNCHANGED << agentTaskAlloc, deps, objectTargets, taskState, nextAttemptOf >>
+    /\ UNCHANGED << deps, objectTargets, taskState, nextAttemptOf >>
 
 SetTaskRetries(T, U) ==
     /\ T /= {}
@@ -131,38 +124,36 @@ SetTaskRetries(T, U) ==
     /\ \E f \in Bijection(T, U):
         nextAttemptOf' =
             [t \in Task |-> IF t \in T THEN f[t] ELSE nextAttemptOf[t]]
-    /\ UNCHANGED << agentTaskAlloc, taskState, deps, objectState, objectTargets >>
+    /\ UNCHANGED << taskState, deps, objectState, objectTargets >>
 
 StageTasks(T) ==
     /\ T /= {} /\ T \subseteq RegisteredTask
     /\ AllPredecessors(deps, T) \subseteq CompletedObject
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_STAGED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, deps, objectState, objectTargets >>
+    /\ UNCHANGED << nextAttemptOf, deps, objectState, objectTargets >>
 
 DiscardTasks(T) ==
     /\ T /= {}
     /\ T \subseteq RegisteredTask \union StagedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_DISCARDED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, deps, objectState, objectTargets >>
+    /\ UNCHANGED << nextAttemptOf, deps, objectState, objectTargets >>
 
-AssignTasks(a, T) ==
+AssignTasks(T) ==
     /\ T /= {} /\ T \subseteq StagedTask
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \union T]
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_ASSIGNED ELSE taskState[t]]
     /\ UNCHANGED << nextAttemptOf, deps, objectState, objectTargets >>
 
-ReleaseTasks(a, T) ==
-    /\ T /= {} /\ T \subseteq agentTaskAlloc[a]
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
+ReleaseTasks(T) ==
+    /\ T /= {} /\ T \subseteq AssignedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_STAGED ELSE taskState[t]]
     /\ UNCHANGED << nextAttemptOf, deps, objectState, objectTargets >>
 
-ProcessTasks(a, T) ==
-    /\ T /= {} /\ T \subseteq agentTaskAlloc[a]
+ProcessTasks(T) ==
+    /\ T /= {} /\ T \subseteq AssignedTask
     /\ \/ taskState' =
             [t \in Task |-> IF t \in T THEN TASK_SUCCEEDED ELSE taskState[t]]
        \/ taskState' =
@@ -170,7 +161,6 @@ ProcessTasks(a, T) ==
        \/ /\ \A t \in T: Cardinality(PreviousAttempts(t)) < MaxRetries
           /\ taskState' =
             [t \in Task |-> IF t \in T THEN TASK_FAILED ELSE taskState[t]]
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
     /\ UNCHANGED << nextAttemptOf, deps, objectState, objectTargets >>
 
 \* Guard future refactor
@@ -186,7 +176,7 @@ CompleteTasks(T) ==
             => \E t \in (Predecessors(deps, o) \ T) : t \notin UNION {CompletedTask, AbortedTask, RetriedTask}
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_COMPLETED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, deps, objectState, objectTargets >>
+    /\ UNCHANGED << nextAttemptOf, deps, objectState, objectTargets >>
 
 AbortTasks(T) ==
     /\ T /= {} /\ T \subseteq DiscardedTask
@@ -195,14 +185,14 @@ AbortTasks(T) ==
             => \E t \in (Predecessors(deps, o) \ T) : t \notin UNION {CompletedTask, AbortedTask, RetriedTask}
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_ABORTED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, deps, objectState, objectTargets >>
+    /\ UNCHANGED << nextAttemptOf, deps, objectState, objectTargets >>
 
 RetryTasks(T) ==
     /\ T /= {} /\ T \subseteq FailedTask
     /\ T \intersect UnretriedTask = {}
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_RETRIED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, deps, objectState, objectTargets >>
+    /\ UNCHANGED << nextAttemptOf, deps, objectState, objectTargets >>
 
 Terminating ==
     /\ objectTargets \subseteq (CompletedObject \union AbortedObject)
@@ -233,10 +223,9 @@ Next ==
         \/ StageTasks(T)
         \/ DiscardTasks(T)
         \/ \E U \in SUBSET Task: SetTaskRetries(T, U)
-        \/ \E a \in Agent:
-            \/ AssignTasks(a, T)
-            \/ ReleaseTasks(a, T)
-            \/ ProcessTasks(a, T)
+        \/ AssignTasks(T)
+        \/ ReleaseTasks(T)
+        \/ ProcessTasks(T)
         \/ CompleteTasks(T)
         \/ AbortTasks(T)
         \/ RetryTasks(T)
@@ -264,8 +253,8 @@ Fairness ==
         /\ WF_vars(Predecessors(deps, t) \intersect AbortedObject /= {} /\ DiscardTasks({t}))
         /\ SF_vars(
             /\ \E o \in Object : GP1!IsTaskUpstreamOnOpenPathToTarget(t, o)
-            /\ \E a \in Agent : AssignTasks(a, {t}))
-        /\ SF_vars(\E a \in Agent : ProcessTasks(a, {t}))
+            /\ AssignTasks({t}))
+        /\ SF_vars(ProcessTasks({t}))
         /\ WF_vars(CompleteTasks({t}))
         /\ WF_vars(AbortTasks({t}))
         /\ WF_vars(RetryTasks({t}))

--- a/specs/GraphProcessing2_mc.cfg
+++ b/specs/GraphProcessing2_mc.cfg
@@ -1,5 +1,4 @@
 CONSTANTS
-    Agent = {a}
     Object = {o, p}
     Task = {t}
     NULL = ""

--- a/specs/GraphProcessing2_mc.tla
+++ b/specs/GraphProcessing2_mc.tla
@@ -10,10 +10,10 @@ MCGraphs(Nodes) ==
 --------------------------------------------------------------------------------
 
 (**
- * Symmetry relation between task, object and agent identifiers.
+ * Symmetry relation between task and object identifiers.
  *)
 Symmetry ==
-    Permutations(Task) \union Permutations(Object) \union Permutations(Agent)
+    Permutations(Task) \union Permutations(Object)
 
 (**
  * The finiteness of the task ID set can lead to a suttering when all task IDs

--- a/specs/TaskProcessing1.cfg
+++ b/specs/TaskProcessing1.cfg
@@ -1,5 +1,4 @@
 CONSTANTS
-    Agent = {a, b, c}
     Task = {t, u, v}
     IsDenumerableSet <- IsFiniteSet
 
@@ -8,8 +7,6 @@ SPECIFICATION
 
 INVARIANTS
     TypeOk
-    AssignedStateIntegrity
-    ExclusiveAssignment
 
 PROPERTY
     PermanentFinalization

--- a/specs/TaskProcessing1.tla
+++ b/specs/TaskProcessing1.tla
@@ -1,29 +1,24 @@
 ---------------------------- MODULE TaskProcessing1 ----------------------------
 (*****************************************************************************)
 (* This module specifies an abstract distributed task scheduling system.     *)
-(* Tasks are dynamically submitted and executed by a varying, unknown set of *)
-(* agents. The specification models the allowed behaviors of task assignment *)
-(* and processing, abstracting away from concrete scheduling or coordination *)
-(* mechanisms. It also defines and asserts key safety and liveness           *)
-(* properties of the system.                                                 *)
+(* Tasks are dynamically submitted and executed. The specification models    *)
+(* the allowed behaviors of task assignment and processing, abstracting away *)
+(* from concrete scheduling or coordination mechanisms. It also defines and  *)
+(* asserts key safety and liveness properties of the system.                 *)
 (*****************************************************************************)
 
 EXTENDS DenumerableSets, FiniteSets
 
 CONSTANTS
-    Agent,   \* Abstract set of all agents
     Task     \* Abstract set of all tasks
 
 ASSUMPTION TP1Assumptions ==
-    /\ Agent \intersect Task = {}
-    /\ IsFiniteSet(Agent)
-    /\ IsDenumerableSet(Task)
+    IsDenumerableSet(Task)
 
 VARIABLES
-    agentTaskAlloc, \* agentTaskAlloc[a] is the set of tasks currently assigned to agent a
     taskState       \* taskState[t] records the current lifecycle state of task t
 
-vars == << agentTaskAlloc, taskState >>
+vars == << taskState >>
 
 -------------------------------------------------------------------------------
 
@@ -36,12 +31,10 @@ INSTANCE TaskStates
 (**
  * TYPE INVARIANT
  * Claims that all state variables always take values of the expected form.
- *   - agentTaskAlloc is a function mapping each agent to a subset of tasks.
  *   - taskState is a function mapping each task to one of the defined states.
  *)
 TypeOk ==
-    /\ agentTaskAlloc \in [Agent -> SUBSET Task]
-    /\ taskState \in [Task -> TP1State]
+    taskState \in [Task -> TP1State]
 
 -------------------------------------------------------------------------------
 
@@ -51,11 +44,10 @@ TypeOk ==
 
 (**
  * INITIAL STATE
- * Initially, no task has been registered and no agent holds any task.
+ * Initially, no task has been registered.
  *)
 Init ==
-    /\ agentTaskAlloc = [a \in Agent |-> {}]
-    /\ taskState = [t \in Task |-> TASK_UNKNOWN]
+    taskState = [t \in Task |-> TASK_UNKNOWN]
 
 (**
  * TASK STAGING
@@ -66,7 +58,6 @@ RegisterTasks(T) ==
     /\ T /= {} /\ T \subseteq UnknownTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_REGISTERED ELSE taskState[t]]
-    /\ UNCHANGED agentTaskAlloc
 
 (**
  * TASK STAGING
@@ -76,49 +67,42 @@ StageTasks(T) ==
     /\ T /= {} /\ T \subseteq RegisteredTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_STAGED ELSE taskState[t]]
-    /\ UNCHANGED agentTaskAlloc
 
 (**
  * TASK BYPASS
  * A set 'T' of registered or staged tasks is moved directly to the processed
- * state, bypassing agent assignment and execution.
+ * state, bypassing assignment and execution.
  *)
 DiscardTasks(T) ==
     /\ T /= {} 
     /\ T \subseteq RegisteredTask \union StagedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_PROCESSED ELSE taskState[t]]
-    /\ UNCHANGED agentTaskAlloc
 
 (**
  * TASK ASSIGNMENT
- * An agent 'a' takes responsibility for processing a set 'T' of staged
- * tasks.
+ * A set 'T' of staged tasks is assigned for processing.
  *)
-AssignTasks(a, T) ==
+AssignTasks(T) ==
     /\ T /= {} /\ T \subseteq StagedTask
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \union T]
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_ASSIGNED ELSE taskState[t]]
 
 (**
  * TASK RELEASE
- * An agent 'a' postpones a set 'T' of tasks it currently holds.
+ * A set 'T' of assigned tasks is released back to the staged pool.
  *)
-ReleaseTasks(a, T) ==
-    /\ T /= {} /\ T \subseteq agentTaskAlloc[a]
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
+ReleaseTasks(T) ==
+    /\ T /= {} /\ T \subseteq AssignedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_STAGED ELSE taskState[t]]
 
 (**
  * TASK PROCESSING
- * An agent 'a' completes the processing of a set 'T' of tasks it currently
- * holds.
+ * A set 'T' of assigned tasks completes processing.
  *)
-ProcessTasks(a, T) ==
-    /\ T /= {} /\ T \subseteq agentTaskAlloc[a]
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
+ProcessTasks(T) ==
+    /\ T /= {} /\ T \subseteq AssignedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_PROCESSED ELSE taskState[t]]
 
@@ -130,12 +114,11 @@ FinalizeTasks(T) ==
     /\ T /= {} /\ T \subseteq ProcessedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_FINALIZED ELSE taskState[t]]
-    /\ UNCHANGED agentTaskAlloc
 
 (**
  * TERMINAL STATE
  * Action representing the terminal state of the system, reached when
- * there are no more tasks being processed (i.e., assigned to an agent or not
+ * there are no more tasks being processed (i.e., assigned or not
  * yet finalized).
  *)
 Terminating ==
@@ -158,25 +141,24 @@ Next ==
         \/ RegisterTasks(T)
         \/ StageTasks(T)
         \/ DiscardTasks(T)
-        \/ \E a \in Agent:
-            \/ AssignTasks(a, T)
-            \/ ReleaseTasks(a, T)
-            \/ ProcessTasks(a, T)
+        \/ AssignTasks(T)
+        \/ ReleaseTasks(T)
+        \/ ProcessTasks(T)
         \/ FinalizeTasks(T)
     \/ Terminating
 
 (**
  * FAIRNESS CONDITIONS
  * Ensure that progress is eventually made for tasks that can act.
- *   - A task cannot be assigned to an agent an infinite number of times
+ *   - A task cannot be assigned an infinite number of times
  *     without eventually being processed.
  *   - A task cannot remain indefinitely processed without being eventually
  *     finalized.
  *)
 Fairness ==
     \A t \in Task:
-        /\ EventuallyProcessed(t) :: SF_vars(\E a \in Agent : ProcessTasks(a, {t}))
-        /\ EventuallyFinalized(t) :: WF_vars(FinalizeTasks({t}))
+        /\ SF_vars(ProcessTasks({t}))
+        /\ WF_vars(FinalizeTasks({t}))
 
 (**
  * Full system specification.
@@ -194,22 +176,6 @@ Spec ==
 
 (**
  * SAFETY
- * A task is assigned to an agent if and only if it is in the ASISGNED state.
- *)
-AssignedStateIntegrity ==
-    \A t \in Task:
-        t \in AssignedTask <=> \E a \in Agent: t \in agentTaskAlloc[a]
-
-(**
- * SAFETY
- * No task is held by multiple agents at the same time*
- *)
-ExclusiveAssignment ==
-    \A a, b \in Agent :
-        a /= b => agentTaskAlloc[a] \intersect agentTaskAlloc[b] = {}
-
-(**
- * SAFETY
  * Once a task reaches the FINALIZED state, it remains there permanently.
  *)
 PermanentFinalization ==
@@ -217,7 +183,7 @@ PermanentFinalization ==
 
 (**
  * LIVENESS
- * Any task assigned to an agent will eventually be either released back 
+ * Any task assigned will eventually be either released back 
  * to the staged pool or successfully processed.
  *)
 EventualDeallocation ==
@@ -226,7 +192,7 @@ EventualDeallocation ==
 
 (**
  * LIVENESS
- * If a task is repeatedly assigned to agents, it must eventually reach 
+ * If a task is repeatedly assigned, it must eventually reach 
  * the processed state.
  *)
 EventualProcessing ==

--- a/specs/TaskProcessing1_proofs.tla
+++ b/specs/TaskProcessing1_proofs.tla
@@ -18,82 +18,24 @@ LEMMA LemType == Init /\ [][Next]_vars => []TypeOk
 THEOREM TP1_Type == Spec => []TypeOk
 BY LemType DEF Spec
 
-TaskSafetyInv ==
-    /\ TypeOk
-    /\ AssignedStateIntegrity
-    /\ ExclusiveAssignment
-
-LEMMA LemTaskSafetyInv == Init /\ [][Next]_vars => []TaskSafetyInv
-<1>. USE DEF TypeOk, AssignedStateIntegrity, ExclusiveAssignment, AssignedTask
-<1>1. TypeOk /\ Init => AssignedStateIntegrity /\ ExclusiveAssignment
-    BY DEF Init
-<1>2. TypeOk /\ AssignedStateIntegrity /\ ExclusiveAssignment /\ [Next]_vars
-      => AssignedStateIntegrity' /\ ExclusiveAssignment'
-    <2>. SUFFICES ASSUME TypeOk, AssignedStateIntegrity, ExclusiveAssignment, [Next]_vars
-                  PROVE AssignedStateIntegrity' /\ ExclusiveAssignment'
-        OBVIOUS
-    <2>. USE DEF TypeOk, AssignedStateIntegrity, ExclusiveAssignment, AssignedTask
-    <2>1. ASSUME NEW T \in SUBSET Task, RegisterTasks(T)
-          PROVE AssignedStateIntegrity' /\ ExclusiveAssignment'
-        BY <2>1 DEF RegisterTasks, UnknownTask
-    <2>2. ASSUME NEW T \in SUBSET Task, StageTasks(T)
-          PROVE AssignedStateIntegrity' /\ ExclusiveAssignment'
-        BY <2>2 DEF StageTasks, RegisteredTask
-    <2>3. ASSUME NEW T \in SUBSET Task, DiscardTasks(T)
-          PROVE AssignedStateIntegrity' /\ ExclusiveAssignment'
-        BY <2>3 DEF DiscardTasks, RegisteredTask, StagedTask
-    <2>4. ASSUME NEW T \in SUBSET Task, NEW a \in Agent, AssignTasks(a, T)
-          PROVE AssignedStateIntegrity' /\ ExclusiveAssignment'
-        BY <2>4, ZenonT(30) DEF AssignTasks, StagedTask
-    <2>5. ASSUME NEW T \in SUBSET Task, NEW a \in Agent, ReleaseTasks(a, T)
-          PROVE AssignedStateIntegrity' /\ ExclusiveAssignment'
-        BY <2>5, ZenonT(30) DEF ReleaseTasks
-    <2>6. ASSUME NEW T \in SUBSET Task, NEW a \in Agent, ProcessTasks(a, T)
-          PROVE AssignedStateIntegrity' /\ ExclusiveAssignment'
-        BY <2>6, ZenonT(30) DEF ProcessTasks
-    <2>7. ASSUME NEW T \in SUBSET Task, FinalizeTasks(T)
-          PROVE AssignedStateIntegrity' /\ ExclusiveAssignment'
-        BY <2>7 DEF FinalizeTasks, ProcessedTask
-    <2>8. CASE Terminating
-        BY <2>8 DEF Terminating, vars
-    <2>9. CASE UNCHANGED vars
-        BY <2>9 DEF vars
-    <2>. QED
-        BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8, <2>9 DEF Next
-<1>. QED
-    BY <1>1, <1>2, LemType, PTL DEF TaskSafetyInv
-
-THEOREM TP1_TaskSafetyInv == Spec => []TaskSafetyInv
-BY LemTaskSafetyInv DEF Spec
-
 THEOREM TP1_PermanentFinalization == Spec => PermanentFinalization
 <1>. SUFFICES ASSUME NEW t \in Task
                 PROVE Spec => [](t \in FinalizedTask => [](t \in FinalizedTask))
     BY DEF PermanentFinalization
-<1>1. TaskSafetyInv /\ t \in FinalizedTask /\ [Next]_vars
+<1>1. TypeOk /\ t \in FinalizedTask /\ [Next]_vars
             => (t \in FinalizedTask)'
-    BY DEF TaskSafetyInv, AssignedStateIntegrity, Next, vars, RegisterTasks,
+    BY DEF TypeOk, Next, vars, RegisterTasks,
     StageTasks, DiscardTasks, AssignTasks, ReleaseTasks, ProcessTasks,
     FinalizeTasks, Terminating, UnknownTask, RegisteredTask, StagedTask,
     AssignedTask, ProcessedTask, FinalizedTask
 <1>2. QED
-    BY <1>1, TP1_TaskSafetyInv, PTL DEF Spec
+    BY <1>1, TP1_Type, PTL DEF Spec
 
 LEMMA AssignmentEnablesProcessing ==
-        ASSUME NEW t \in Task, TaskSafetyInv
+        ASSUME NEW t \in Task, TypeOk
         PROVE t \in AssignedTask
-              => ENABLED <<\E a \in Agent: ProcessTasks(a, {t})>>_vars
-<1>1. <<\E a \in Agent: ProcessTasks(a, {t})>>_vars
-      <=> \E a \in Agent: ProcessTasks(a, {t})
-    BY DEF TaskSafetyInv, TypeOk, vars, ProcessTasks
-<1>2. (ENABLED <<\E a \in Agent: ProcessTasks(a, {t})>>_vars)
-      <=> ENABLED (\E a \in Agent: ProcessTasks(a, {t}))
-    BY <1>1, ENABLEDaxioms
-<1>3. t \in AssignedTask => ENABLED (\E a \in Agent: ProcessTasks(a, {t}))
-    BY ExpandENABLED DEF TaskSafetyInv, TypeOk, AssignedStateIntegrity,
-    ProcessTasks
-<1>. QED
-    BY <1>2, <1>3
+              => ENABLED <<ProcessTasks({t})>>_vars
+BY ExpandENABLED DEF ProcessTasks, AssignedTask, vars
 
 THEOREM TP1_EventualDeallocation == Spec => EventualDeallocation
 <1>. SUFFICES ASSUME NEW t \in Task
@@ -107,10 +49,9 @@ THEOREM TP1_EventualDeallocation == Spec => EventualDeallocation
                   PROVE [\/ RegisterTasks(T)
                          \/ StageTasks(T)
                          \/ DiscardTasks(T)
-                         \/ \E a \in Agent:
-                             \/ AssignTasks(a, T)
-                             \/ ReleaseTasks(a, T)
-                             \/ ProcessTasks(a, T)
+                         \/ AssignTasks(T)
+                         \/ ReleaseTasks(T)
+                         \/ ProcessTasks(T)
                          \/ FinalizeTasks(T)
                          \/ Terminating]_vars => \/ (t \in AssignedTask)'
                                                  \/ (t \in StagedTask)'
@@ -120,39 +61,39 @@ THEOREM TP1_EventualDeallocation == Spec => EventualDeallocation
         BY DEF RegisterTasks, StageTasks, DiscardTasks, AssignTasks, ReleaseTasks,
         ProcessTasks, FinalizeTasks, Terminating, vars, UnknownTask, RegisteredTask,
         StagedTask, AssignedTask, ProcessedTask, FinalizedTask
-<1>2. TaskSafetyInv /\ t \in AssignedTask /\ <<\E a \in Agent : ProcessTasks(a, {t})>>_vars
+<1>2. TypeOk /\ t \in AssignedTask /\ <<ProcessTasks({t})>>_vars
       => (t \in ProcessedTask)'
-    BY DEF TaskSafetyInv, TypeOk, ProcessTasks, AssignedTask, ProcessedTask
-<1>3. TaskSafetyInv /\ t \in AssignedTask
-      => ENABLED <<\E a \in Agent : ProcessTasks(a, {t})>>_vars
+    BY DEF TypeOk, ProcessTasks, AssignedTask, ProcessedTask
+<1>3. TypeOk /\ t \in AssignedTask
+      => ENABLED <<ProcessTasks({t})>>_vars
     BY AssignmentEnablesProcessing
-<1>4. Fairness => SF_vars(\E a \in Agent : ProcessTasks(a, {t}))
+<1>4. Fairness => SF_vars(ProcessTasks({t}))
     BY Isa DEF Fairness
 <1>. QED
-    BY <1>1, <1>2, <1>3, <1>4, TP1_TaskSafetyInv, PTL DEF Spec
+    BY <1>1, <1>2, <1>3, <1>4, TP1_Type, PTL DEF Spec
 
 THEOREM TP1_EventualProcessing == Spec => EventualProcessing
 <1>. SUFFICES ASSUME NEW t \in Task
               PROVE Spec => ([]<>(t \in AssignedTask) => <>(t \in ProcessedTask))
     BY DEF EventualProcessing
-<1>1. TaskSafetyInv /\ t \in AssignedTask
-      => ENABLED <<\E a \in Agent: ProcessTasks(a, {t})>>_vars
+<1>1. TypeOk /\ t \in AssignedTask
+      => ENABLED <<ProcessTasks({t})>>_vars
     BY AssignmentEnablesProcessing
-<1>2. <<\E a \in Agent: ProcessTasks(a, {t})>>_vars
+<1>2. <<ProcessTasks({t})>>_vars
       => (t \in ProcessedTask)'
     BY DEF ProcessTasks, ProcessedTask
-<1>3. Fairness => Fairness!EventuallyProcessed(t)
+<1>3. Fairness => SF_vars(ProcessTasks({t}))
     BY Isa DEF Fairness
 <1>. QED
-    BY <1>1, <1>2, <1>3, TP1_TaskSafetyInv, PTL DEF Spec
+    BY <1>1, <1>2, <1>3, TP1_Type, PTL DEF Spec
 
 THEOREM TP1_EventualFinalization == Spec => EventualFinalization
 <1>. SUFFICES ASSUME NEW t \in Task
                 PROVE Spec => t \in ProcessedTask ~> t \in FinalizedTask
     BY DEF EventualFinalization
-<1>1. TaskSafetyInv /\ t \in ProcessedTask /\ [Next]_vars
+<1>1. TypeOk /\ t \in ProcessedTask /\ [Next]_vars
       => (t \in ProcessedTask)' \/ (t \in FinalizedTask)'
-    BY DEF TaskSafetyInv, TypeOk, AssignedStateIntegrity, Next, vars, RegisterTasks,
+    BY DEF TypeOk, Next, vars, RegisterTasks,
     StageTasks, DiscardTasks, AssignTasks, ReleaseTasks, ProcessTasks, FinalizeTasks,
     Terminating, UnknownTask, RegisteredTask, StagedTask, AssignedTask, ProcessedTask,
     FinalizedTask
@@ -160,10 +101,10 @@ THEOREM TP1_EventualFinalization == Spec => EventualFinalization
     BY ExpandENABLED DEF FinalizeTasks, vars, ProcessedTask
 <1>3. t \in ProcessedTask /\ <<FinalizeTasks({t})>>_vars => (t \in FinalizedTask)'
     BY DEF FinalizeTasks, ProcessedTask, FinalizedTask
-<1>4. Fairness => Fairness!EventuallyFinalized(t)
+<1>4. Fairness => WF_vars(FinalizeTasks({t}))
     BY Isa DEF Fairness
 <1>. QED
-    BY <1>1, <1>2, <1>3, <1>4, TP1_TaskSafetyInv, PTL DEF Spec
+    BY <1>1, <1>2, <1>3, <1>4, TP1_Type, PTL DEF Spec
 
 THEOREM TP1_EventualQuiescence == Spec => EventualQuiescence
 <1>. SUFFICES ASSUME NEW t \in Task
@@ -171,15 +112,15 @@ THEOREM TP1_EventualQuiescence == Spec => EventualQuiescence
                                                      \/ [](t \in StagedTask)
                                                      \/ [](t \in FinalizedTask))
     BY DEF EventualQuiescence
-<1>1. TaskSafetyInv /\ t \in RegisteredTask /\ [Next]_vars
+<1>1. TypeOk /\ t \in RegisteredTask /\ [Next]_vars
       => (t \in RegisteredTask)' \/ (t \in StagedTask)'  \/ (t \in ProcessedTask)'
-    BY DEF TaskSafetyInv, TypeOk, AssignedStateIntegrity, Next, vars, RegisterTasks,
+    BY DEF TypeOk, Next, vars, RegisterTasks,
     StageTasks, DiscardTasks, AssignTasks, ReleaseTasks, ProcessTasks, FinalizeTasks,
     Terminating, UnknownTask, RegisteredTask, StagedTask, AssignedTask, ProcessedTask,
     FinalizedTask
-<1>2. TaskSafetyInv /\ t \in StagedTask /\ [Next]_vars
+<1>2. TypeOk /\ t \in StagedTask /\ [Next]_vars
       => (t \in StagedTask)' \/ (t \in AssignedTask)' \/ (t \in ProcessedTask)'
-    BY DEF TaskSafetyInv, TypeOk, AssignedStateIntegrity, Next, vars, RegisterTasks,
+    BY DEF TypeOk, Next, vars, RegisterTasks,
     StageTasks, DiscardTasks, AssignTasks, ReleaseTasks, ProcessTasks, FinalizeTasks,
     Terminating, UnknownTask, RegisteredTask, StagedTask, AssignedTask, ProcessedTask,
     FinalizedTask
@@ -192,6 +133,6 @@ THEOREM TP1_EventualQuiescence == Spec => EventualQuiescence
 <1>6. Spec => [](t \in FinalizedTask => [](t \in FinalizedTask))
     BY TP1_PermanentFinalization DEF PermanentFinalization
 <1>. QED
-    BY <1>1, <1>2, <1>3, <1>4, <1>5, <1>6, TP1_TaskSafetyInv, PTL DEF Spec
+    BY <1>1, <1>2, <1>3, <1>4, <1>5, <1>6, TP1_Type, PTL DEF Spec
 
 ================================================================================

--- a/specs/TaskProcessing2.tla
+++ b/specs/TaskProcessing2.tla
@@ -7,24 +7,20 @@
 EXTENDS DenumerableSetTheorems, FiniteSetTheorems, Functions, Naturals, TLAPS, Utils, WellFoundedInduction
 
 CONSTANTS
-    Agent,    \* Set of agent identifiers
     Task,     \* Set of task identifiers
     MaxRetries, \* Maximal number of retries for tasks
     NULL        \* Constant representing a null value
 
 ASSUME TP2Assumptions ==
-    /\ Agent \intersect Task = {}
-    /\ IsFiniteSet(Agent)
     /\ IsDenumerableSet(Task)
     /\ MaxRetries \in Nat
     /\ NULL \notin Task
 
 VARIABLES
-    agentTaskAlloc,   \* agentTaskAlloc[a]: set of tasks assigned to agent a
     taskState,        \* taskState[t]: current lifecycle state of task t
     nextAttemptOf     \* nextAttemptOf[t]: ID of the task retrying t (NULL if none)
 
-vars == << agentTaskAlloc, taskState, nextAttemptOf >>
+vars == << taskState, nextAttemptOf >>
 
 -------------------------------------------------------------------------------
 
@@ -38,12 +34,10 @@ INSTANCE TaskRetries
 (**
  * TYPE INVARIANT
  * Claims that all state variables always take values of the expected form.
- *   - agentTaskAlloc is a function mapping each agent to a subset of tasks.
  *   - taskState is a function mapping each task to one of the defined states.
  *   - nextAttemptOf is a function mapping each task to another task or NULL.
  *)
 TypeOk == 
-    /\ agentTaskAlloc \in [Agent -> SUBSET Task]
     /\ taskState \in [Task -> TP2State]
     /\ nextAttemptOf \in [Task -> Task \union {NULL}]
 
@@ -55,11 +49,9 @@ TypeOk ==
 
 (**
  * INITIAL STATE
- * Initially, no task has been registered and retried and no agent holds any
- * task.
+ * Initially, no task has been registered and retried.
  *)
 Init ==
-    /\ agentTaskAlloc = [a \in Agent |-> {}]
     /\ taskState = [t \in Task |-> TASK_UNKNOWN]
     /\ nextAttemptOf = [t \in Task |-> NULL]
 
@@ -72,7 +64,7 @@ RegisterTasks(T) ==
     /\ IsFiniteSet(T)
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_REGISTERED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf >>
+    /\ UNCHANGED nextAttemptOf
 
 (**
  * TASK STAGING
@@ -82,19 +74,19 @@ StageTasks(T) ==
     /\ T /= {} /\ T \subseteq RegisteredTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_STAGED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf >>
+    /\ UNCHANGED nextAttemptOf
 
 (**
  * TASK BYPASS
  * A set 'T' of registered or staged tasks is moved directly to the processed
- * state, bypassing agent assignment and execution.
+ * state, bypassing assignment and execution.
  *)
 DiscardTasks(T) ==
     /\ T /= {}
     /\ T \subseteq RegisteredTask \union StagedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_DISCARDED ELSE taskState[t]]
-    /\ UNCHANGED <<agentTaskAlloc, nextAttemptOf>>
+    /\ UNCHANGED nextAttemptOf
 
 (**
  * TASK RETRIES RECORDING
@@ -109,41 +101,38 @@ SetTaskRetries(T, U) ==
     /\ \E f \in Bijection(T, U):
         nextAttemptOf' =
             [t \in Task |-> IF t \in T THEN f[t] ELSE nextAttemptOf[t]]
-    /\ UNCHANGED << agentTaskAlloc, taskState >>
+    /\ UNCHANGED taskState
 
 (**
  * TASK ASSIGNMENT
- * Agent 'a' claims set 'T' for processing.
+ * A set 'T' of staged tasks is assigned for processing.
  *)
-AssignTasks(a, T) ==
+AssignTasks(T) ==
     /\ T /= {} /\ T \subseteq StagedTask
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \union T]
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_ASSIGNED ELSE taskState[t]]
     /\ UNCHANGED nextAttemptOf
 
 (**
  * TASK RELEASE
- * Agent 'a' returns tasks 'T' to the STAGED state without completing their
- * processing.
+ * A set 'T' of assigned tasks is released back to the STAGED state.
  *)
-ReleaseTasks(a, T) ==
-    /\ T /= {} /\ T \subseteq agentTaskAlloc[a]
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
+ReleaseTasks(T) ==
+    /\ T /= {} /\ T \subseteq AssignedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_STAGED ELSE taskState[t]]
     /\ UNCHANGED nextAttemptOf
 
 (**
  * TASK PROCESSING
- * Agent 'a' finishes tasks 'T', sorting them according to the possible
- * processing states i.e., Success (S), Failure (F), or Crash (C). 
+ * A set 'T' of assigned tasks finishes processing, sorted according to the
+ * possible processing states i.e., Success (S), Failure (F), or Crash (C). 
  * Failed tasks are tasks that can be retried (their execution will be retried
  * by another task), while crashed tasks will simply be aborted.  A task can
  * only fail (F) if it hasn't exceeded the maximum number of retries.
  *)
-ProcessTasks(a, T) ==
-    /\ T /= {} /\ T \subseteq agentTaskAlloc[a]
+ProcessTasks(T) ==
+    /\ T /= {} /\ T \subseteq AssignedTask
     /\ \/ taskState' =
             [t \in Task |-> IF t \in T THEN TASK_SUCCEEDED ELSE taskState[t]]
        \/ taskState' =
@@ -151,7 +140,6 @@ ProcessTasks(a, T) ==
        \/ /\ \A t \in T: Cardinality(PreviousAttempts(t)) < MaxRetries
           /\ taskState' =
             [t \in Task |-> IF t \in T THEN TASK_FAILED ELSE taskState[t]]
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
     /\ UNCHANGED nextAttemptOf
 
 (**
@@ -162,7 +150,7 @@ CompleteTasks(T) ==
     /\ T /= {} /\ T \subseteq SucceededTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_COMPLETED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf >>
+    /\ UNCHANGED nextAttemptOf
 
 (**
  * TASK ABORTION
@@ -173,7 +161,7 @@ AbortTasks(T) ==
     /\ T /= {} /\ T \subseteq DiscardedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_ABORTED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf >>
+    /\ UNCHANGED nextAttemptOf
 
 (**
  * TASK RETRY FINALIZATION
@@ -186,7 +174,7 @@ RetryTasks(T) ==
     /\ T \intersect UnretriedTask = {}
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_RETRIED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf >>
+    /\ UNCHANGED nextAttemptOf
 
 (**
  * TERMINAL STATE
@@ -216,10 +204,9 @@ Next ==
         \/ StageTasks(T)
         \/ DiscardTasks(T)
         \/ \E U \in SUBSET Task: SetTaskRetries(T, U)
-        \/ \E a \in Agent:
-            \/ AssignTasks(a, T)
-            \/ ReleaseTasks(a, T)
-            \/ ProcessTasks(a, T)
+        \/ AssignTasks(T)
+        \/ ReleaseTasks(T)
+        \/ ProcessTasks(T)
         \/ CompleteTasks(T)
         \/ AbortTasks(T)
         \/ RetryTasks(T)
@@ -234,7 +221,7 @@ Next ==
  *     eventually registered.
  *   - A new task attempt cannot reamin indefinitely staged without being
  *     eventually staged.
- *   - A task cannot be assigned to an agent an infinite number of times
+ *   - A task cannot be assigned an infinite number of times
  *     without eventually being processed.
  *   - A task cannot remain indefinitely succeeded without being eventually
  *     completed.
@@ -248,7 +235,7 @@ Fairness ==
         /\ WF_vars(\E u \in Task : SetTaskRetries({t}, {u}))
         /\ WF_vars(RegisterTasks({nextAttemptOf[t]}))
         /\ WF_vars(StageTasks({nextAttemptOf[t]}))
-        /\ SF_vars(\E a \in Agent : ProcessTasks(a, {t}))
+        /\ SF_vars(ProcessTasks({t}))
         /\ WF_vars(CompleteTasks({t}))
         /\ WF_vars(AbortTasks({t}))
         /\ WF_vars(RetryTasks({t}))

--- a/specs/TaskProcessing2_mc.cfg
+++ b/specs/TaskProcessing2_mc.cfg
@@ -1,6 +1,5 @@
 CONSTANTS
-    Agent = {a, b}
-    Task = {t, u, v}
+    Task = {t, u}
     NULL = ""
     MaxRetries = 1
     IsDenumerableSet <- IsFiniteSet

--- a/specs/TaskProcessing3.tla
+++ b/specs/TaskProcessing3.tla
@@ -19,26 +19,22 @@
 EXTENDS DenumerableSets, FiniteSets, Functions, Naturals
 
 CONSTANTS
-    Agent,    \* Set of agent identifiers
     Task,     \* Set of task identifiers
     MaxRetries, \* Maximal number of retries for tasks
     NULL        \* Constant representing a null value
 
 ASSUME TP3Assumptions ==
-    /\ Agent \intersect Task = {}
-    /\ IsFiniteSet(Agent)
     /\ IsDenumerableSet(Task)
     /\ MaxRetries \in Nat
     /\ NULL \notin Task
 
 VARIABLES
-    agentTaskAlloc,   \* agentTaskAlloc[a]: set of tasks assigned to agent a
     taskState,        \* taskState[t]: current lifecycle state of task t
     nextAttemptOf,    \* nextAttemptOf[t]: ID of the task retrying t (NULL if none)
     stoppingRequested,  \* stoppingRequested: set of tasks for which cancellation has been requested
     pausingRequested  \* pausingRequested: set of tasks for which pausing has been requested
 
-vars == << agentTaskAlloc, taskState, nextAttemptOf, stoppingRequested, pausingRequested >>
+vars == << taskState, nextAttemptOf, stoppingRequested, pausingRequested >>
 
 -------------------------------------------------------------------------------
 
@@ -50,14 +46,12 @@ INSTANCE TaskRetries
 (**
  * TYPE INVARIANT
  * Claims that all state variables always take values of the expected form.
- *   - agentTaskAlloc is a function mapping each agent to a subset of tasks.
  *   - taskState is a function mapping each task to one of the defined states.
  *   - nextAttemptOf is a function mapping each task to another task or NULL.
  *   - stoppingRequested is a set of tasks.
  *   - pausingRequested is a set of tasks.
  *)
 TypeOk == 
-    /\ agentTaskAlloc \in [Agent -> SUBSET Task]
     /\ taskState \in [Task -> TP3State]
     /\ nextAttemptOf \in [Task -> Task \union {NULL}]
     /\ stoppingRequested \in SUBSET Task
@@ -71,11 +65,10 @@ TypeOk ==
 
 (**
  * INITIAL STATE
- * Initially, no task has been registered and no agent holds any task. In
- * addition, no tasks were retried or requested to be canceled or paused.
+ * Initially, no task has been registered. In addition, no tasks were retried
+ * or requested to be canceled or paused.
  *)
 Init ==
-    /\ agentTaskAlloc = [a \in Agent |-> {}]
     /\ taskState = [t \in Task |-> TASK_UNKNOWN]
     /\ nextAttemptOf = [t \in Task |-> NULL]
     /\ stoppingRequested = {}
@@ -91,7 +84,7 @@ RegisterTasks(T) ==
     /\ IsFiniteSet(T)
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_REGISTERED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested, pausingRequested >>
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested, pausingRequested >>
 
 (**
  * TASK STAGING
@@ -101,19 +94,19 @@ StageTasks(T) ==
     /\ T /= {} /\ T \subseteq RegisteredTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_STAGED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested, pausingRequested >>
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested, pausingRequested >>
 
 (**
  * TASK BYPASS
  * A set 'T' of registered or staged tasks is moved directly to the processed
- * state, bypassing agent assignment and execution.
+ * state, bypassing assignment and execution.
  *)
 DiscardTasks(T) ==
     /\ T /= {}
     /\ T \subseteq UNION {RegisteredTask, StagedTask, PausedTask}
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_DISCARDED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested, pausingRequested >>
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested, pausingRequested >>
 
 (**
  * TASK RETRIES RECORDING
@@ -129,50 +122,47 @@ SetTaskRetries(T, U) ==
     /\ \E f \in Bijection(T, U):
         nextAttemptOf' =
             [t \in Task |-> IF t \in T THEN f[t] ELSE nextAttemptOf[t]]
-    /\ UNCHANGED << agentTaskAlloc, taskState, stoppingRequested, pausingRequested >>
+    /\ UNCHANGED << taskState, stoppingRequested, pausingRequested >>
 
 (**
  * TASK ASSIGNMENT
- * An agent 'a' takes responsibility for processing a set 'T' of staged
- * tasks. Tasks can be assigned iff their cancelation or pausing have not been
- * requested.
+ * A set 'T' of staged tasks is assigned for processing. Tasks can be
+ * assigned iff their cancelation or pausing have not been requested.
  *)
-AssignTasks(a, T) ==
+AssignTasks(T) ==
     /\ T /= {} /\ T \subseteq StagedTask
     /\ T \intersect stoppingRequested = {}
     /\ T \intersect pausingRequested = {}
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \union T]
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_ASSIGNED ELSE taskState[t]]
     /\ UNCHANGED << nextAttemptOf, stoppingRequested, pausingRequested >>
 
 (**
  * TASK RELEASE
- * An agent 'a' postpones a set 'T' of tasks it currently holds.
+ * A set 'T' of assigned tasks is released back to the staged pool.
  *)
-ReleaseTasks(a, T) ==
-    /\ T /= {} /\ T \subseteq agentTaskAlloc[a]
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
+ReleaseTasks(T) ==
+    /\ T /= {} /\ T \subseteq AssignedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_STAGED ELSE taskState[t]]
     /\ UNCHANGED << nextAttemptOf, stoppingRequested, pausingRequested >>
 
 (**
  * TASK PROCESSING
- * An agent 'a' completes the processing of a set 'T' of tasks it currently
- * holds. Three scenarios are possible:
+ * A set 'T' of assigned tasks completes processing. Three scenarios are
+ * possible:
  *   - Task processing succeeded.
  *   - Task processing failed, but the cause may be transient — retrying
  *     execution is allowed.
  *   - Task crashed irrecoverably - re-execution is prohibited.
  *
- * When an agent acknowledges the completion of the processing of a set of tasks,
+ * When the completion of the processing of a set of tasks is acknowledged,
  * these tasks can have any of the three states mentioned above. The set 'T' is
  * therefore divided into three subsets 'S', 'F', and 'C', corresponding to each
  * of the three possible states.
  *)
-ProcessTasks(a, T) ==
-    /\ T /= {} /\ T \subseteq agentTaskAlloc[a]
+ProcessTasks(T) ==
+    /\ T /= {} /\ T \subseteq AssignedTask
     /\ \/ taskState' =
             [t \in Task |-> IF t \in T THEN TASK_SUCCEEDED ELSE taskState[t]]
        \/ taskState' =
@@ -182,7 +172,6 @@ ProcessTasks(a, T) ==
             [t \in Task |-> IF t \in T THEN TASK_FAILED ELSE taskState[t]]
        \/ taskState' =
             [t \in Task |-> IF t \in T THEN TASK_STOPPED ELSE taskState[t]]
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
     /\ UNCHANGED << nextAttemptOf, stoppingRequested, pausingRequested >>
 
 (**
@@ -193,20 +182,20 @@ CompleteTasks(T) ==
     /\ T /= {} /\ T \subseteq SucceededTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_COMPLETED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested, pausingRequested >>
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested, pausingRequested >>
 
 AbortTasks(T) ==
     /\ T /= {} /\ T \subseteq DiscardedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_ABORTED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested, pausingRequested >>
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested, pausingRequested >>
 
 RetryTasks(T) ==
     /\ T /= {} /\ T \subseteq FailedTask
     /\ T \intersect UnretriedTask = {}
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_RETRIED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested, pausingRequested >>
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested, pausingRequested >>
 
 (**
  * TASK CANCELLATION REQUESTING
@@ -215,17 +204,14 @@ RetryTasks(T) ==
 RequestTasksStopping(T) ==
     /\ T /= {} /\ T \intersect UnknownTask = {}
     /\ stoppingRequested' = stoppingRequested \union T
-    /\ UNCHANGED << agentTaskAlloc, taskState, nextAttemptOf, pausingRequested >>
+    /\ UNCHANGED << taskState, nextAttemptOf, pausingRequested >>
 
 (**
  * TASK CANCELLATION ACKNOWLEDGMENT
- * The request to cancel a set 'T' of tasks is acknowledged. There are two
- * possible scenarios:
- *   - All tasks in 'T' are assigned to agent 'a', in which case they are
- *     released and their states changes to STOPPED.
- *   - No tasks in 'T' is allocated and therefore all tasks are changed to
- *     the STOPPED state, provided that their processing has not already
- *     been completed (i.e., the tasks are in REGISTERED or STAGED states).
+ * The request to cancel a set 'T' of tasks is acknowledged. Tasks not
+ * currently assigned are changed to the STOPPED state, provided that their
+ * processing has not already been completed (i.e., the tasks are in
+ * REGISTERED, STAGED or PAUSED states).
  *)
 StopTasks(T) ==
     /\ T /= {}
@@ -237,7 +223,7 @@ StopTasks(T) ==
                                        \/ t \in PausedTask)
                             THEN TASK_STOPPED
                             ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested, pausingRequested >>
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested, pausingRequested >>
 
 (**
  * TASK PAUSING REQUESTING
@@ -248,24 +234,15 @@ RequestTasksPausing(T) ==
     /\ T /= {} /\ T \intersect UnknownTask = {}
     /\ T \intersect stoppingRequested = {}
     /\ pausingRequested' = pausingRequested \union T
-    /\ UNCHANGED << agentTaskAlloc, taskState, nextAttemptOf, stoppingRequested >>
+    /\ UNCHANGED << taskState, nextAttemptOf, stoppingRequested >>
 
 (**
  * TASK PAUSING ACKNOWLEDGMENT
- * The request to pause a set 'T' of tasks is acknowledged. There are two
- * possible scenarios:
- *   - All tasks in 'T' are assigned to agent 'a', in which case they are
- *     released and their states changes to PAUSED.
- *   - No tasks in 'T' is allocated and therefore all STAGED tasks are set to
- *     the PAUSED state and the other tasks remain in the same state.
+ * The request to pause a set 'T' of tasks is acknowledged. STAGED or
+ * ASSIGNED tasks are set to the PAUSED state.
  *)
 PauseTasks(T) ==
     /\ T /= {} /\ T \subseteq pausingRequested
-    /\ \/ \E a \in Agent:
-            /\ T \subseteq agentTaskAlloc[a]
-            /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
-       \/ /\ T \intersect AssignedTask = {}
-          /\ UNCHANGED agentTaskAlloc
     /\ taskState' =
         [t \in Task |-> IF t \in T /\ (t \in StagedTask \/ t \in AssignedTask)
                             THEN TASK_PAUSED
@@ -284,12 +261,12 @@ ResumeTasks(T) ==
                             THEN TASK_STAGED
                             ELSE taskState[t]]
     /\ pausingRequested' = pausingRequested \ T
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested >>
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested >>
 
 (**
  * TERMINAL STATE
  * Action representing the terminal state of the system, reached when
- * there are no more tasks being processed (i.e., assigned to an agent or not
+ * there are no more tasks being processed (i.e., assigned or not
  * yet finalized i.e., completed, retried, aborted or canceled).
  *)
 Terminating ==
@@ -315,10 +292,9 @@ Next ==
         \/ StageTasks(T)
         \/ DiscardTasks(T)
         \/ \E U \in SUBSET Task: SetTaskRetries(T, U)
-        \/ \E a \in Agent:
-            \/ AssignTasks(a, T)
-            \/ ReleaseTasks(a, T)
-            \/ ProcessTasks(a, T)
+        \/ AssignTasks(T)
+        \/ ReleaseTasks(T)
+        \/ ProcessTasks(T)
         \/ CompleteTasks(T)
         \/ AbortTasks(T)
         \/ RetryTasks(T)
@@ -333,7 +309,7 @@ Next ==
  * FAIRNESS CONDITIONS
  * Ensure that progress is eventually made for tasks that can act.
  *   - A task cannot remain indefinitely failed without being retried.
- *   - A task cannot be assigned to an agent an infinite number of times
+ *   - A task cannot be assigned an infinite number of times
  *     without eventually being processed.
  *   - A task cannot remain indefinitely processed without being eventually
  *     finalized (completed, retried or aborted).
@@ -344,7 +320,7 @@ Fairness ==
         /\ WF_vars(\E u \in Task : SetTaskRetries({t}, {u}))
         /\ WF_vars(RegisterTasks({nextAttemptOf[t]}))
         /\ WF_vars(StageTasks({nextAttemptOf[t]}))
-        /\ SF_vars(\E a \in Agent : ProcessTasks(a, {t}))
+        /\ SF_vars(ProcessTasks({t}))
         /\ WF_vars(CompleteTasks({t}))
         /\ WF_vars(AbortTasks({t}))
         /\ WF_vars(RetryTasks({t}))

--- a/specs/TaskProcessing3_mc.cfg
+++ b/specs/TaskProcessing3_mc.cfg
@@ -1,5 +1,4 @@
 CONSTANTS
-    Agent = {a, b}
     Task = {t, u}
     NULL = ""
     MaxRetries = 1

--- a/specs/TaskProcessing4.tla
+++ b/specs/TaskProcessing4.tla
@@ -8,27 +8,23 @@
 EXTENDS DenumerableSets, FiniteSets, Naturals, TLAPS
 
 CONSTANTS
-    Agent,    \* Set of agent identifiers
     Task,     \* Set of task identifiers
     MaxRetries, \* Maximal number of retries for tasks
     NULL        \* Constant representing a null value
 
 ASSUME TP4Assumptions ==
-    /\ Agent \intersect Task = {}
-    /\ IsFiniteSet(Agent)
     /\ IsDenumerableSet(Task)
     /\ MaxRetries \in Nat
     /\ NULL \notin Task
 
 VARIABLES
-    agentTaskAlloc,    \* agentTaskAlloc[a]: set of tasks assigned to agent a
     taskState,         \* taskState[t]: current lifecycle state of task t
     nextAttemptOf,     \* nextAttemptOf[t]: ID of the task retrying t (NULL if none)
     stoppingRequested, \* stoppingRequested: set of tasks for which cancellation has been requested
     pausingRequested,  \* pausingRequested: set of tasks for which pausing has been requested
     taskDeleted        \* taskDeleted is the set of tasks currently deleted
 
-vars == << agentTaskAlloc, taskState, nextAttemptOf, stoppingRequested,
+vars == << taskState, nextAttemptOf, stoppingRequested,
            pausingRequested, taskDeleted >>
 
 -------------------------------------------------------------------------------
@@ -41,14 +37,12 @@ INSTANCE TaskRetries
 (**
  * TYPE INVARIANT
  * Claims that all state variables always take values of the expected form.
- *   - agentTaskAlloc is a function mapping each agent to a subset of tasks.
  *   - taskState is a function mapping each task to one of the defined states.
  *   - nextAttemptOf is a function mapping each task to another task or NULL.
  *   - stoppingRequested is a set of tasks.
  *   - pausingRequested is a set of tasks.
  *)
 TypeOk == 
-    /\ agentTaskAlloc \in [Agent -> SUBSET Task]
     /\ taskState \in [Task -> TP4State]
     /\ nextAttemptOf \in [Task -> Task \union {NULL}]
     /\ stoppingRequested \in SUBSET Task
@@ -63,11 +57,10 @@ TypeOk ==
 
 (**
  * INITIAL STATE
- * Initially, no task has been registered and no agent holds any task. In
- * addition, no tasks were retried or requested to be canceled or paused.
+ * Initially, no task has been registered. In addition, no tasks were retried
+ * or requested to be canceled or paused.
  *)
 Init ==
-    /\ agentTaskAlloc = [a \in Agent |-> {}]
     /\ taskState = [t \in Task |-> TASK_UNKNOWN]
     /\ nextAttemptOf = [t \in Task |-> NULL]
     /\ stoppingRequested = {}
@@ -84,7 +77,7 @@ RegisterTasks(T) ==
     /\ IsFiniteSet(T)
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_REGISTERED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested,
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested,
                     pausingRequested, taskDeleted >>
 
 (**
@@ -96,13 +89,13 @@ StageTasks(T) ==
     /\ T \intersect taskDeleted = {}
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_STAGED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested,
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested,
                     pausingRequested, taskDeleted >>
 
 (**
  * TASK BYPASS
  * A set 'T' of registered or staged tasks is moved directly to the processed
- * state, bypassing agent assignment and execution.
+ * state, bypassing assignment and execution.
  *)
 DiscardTasks(T) ==
     /\ T /= {}
@@ -110,7 +103,7 @@ DiscardTasks(T) ==
     /\ T \intersect taskDeleted = {}
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_DISCARDED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested,
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested,
                     pausingRequested, taskDeleted >>
 
 (**
@@ -127,21 +120,19 @@ SetTaskRetries(T, U) ==
     /\ \E f \in Bijection(T, U):
         nextAttemptOf' =
             [t \in Task |-> IF t \in T THEN f[t] ELSE nextAttemptOf[t]]
-    /\ UNCHANGED << agentTaskAlloc, taskState, stoppingRequested,
+    /\ UNCHANGED << taskState, stoppingRequested,
                     pausingRequested, taskDeleted >>
 
 (**
  * TASK ASSIGNMENT
- * An agent 'a' takes responsibility for processing a set 'T' of staged
- * tasks. Tasks can be assigned iff their cancelation or pausing have not been
- * requested.
+ * A set 'T' of staged tasks is assigned for processing. Tasks can be
+ * assigned iff their cancelation or pausing have not been requested.
  *)
-AssignTasks(a, T) ==
+AssignTasks(T) ==
     /\ T /= {} /\ T \subseteq StagedTask
     /\ T \intersect taskDeleted = {}
     /\ T \intersect stoppingRequested = {}
     /\ T \intersect pausingRequested = {}
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \union T]
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_ASSIGNED ELSE taskState[t]]
     /\ UNCHANGED << nextAttemptOf, stoppingRequested, pausingRequested,
@@ -149,12 +140,11 @@ AssignTasks(a, T) ==
 
 (**
  * TASK RELEASE
- * An agent 'a' postpones a set 'T' of tasks it currently holds.
+ * A set 'T' of assigned tasks is released back to the staged pool.
  *)
-ReleaseTasks(a, T) ==
-    /\ T /= {} /\ T \subseteq agentTaskAlloc[a]
+ReleaseTasks(T) ==
+    /\ T /= {} /\ T \subseteq AssignedTask
     /\ T \intersect taskDeleted = {}
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_STAGED ELSE taskState[t]]
     /\ UNCHANGED << nextAttemptOf, stoppingRequested, pausingRequested,
@@ -162,20 +152,20 @@ ReleaseTasks(a, T) ==
 
 (**
  * TASK PROCESSING
- * An agent 'a' completes the processing of a set 'T' of tasks it currently
- * holds. Three scenarios are possible:
+ * A set 'T' of assigned tasks completes processing. Three scenarios are
+ * possible:
  *   - Task processing succeeded.
  *   - Task processing failed, but the cause may be transient — retrying
  *     execution is allowed.
  *   - Task crashed irrecoverably - re-execution is prohibited.
  *
- * When an agent acknowledges the completion of the processing of a set of tasks,
+ * When the completion of the processing of a set of tasks is acknowledged,
  * these tasks can have any of the three states mentioned above. The set 'T' is
  * therefore divided into three subsets 'S', 'F', and 'C', corresponding to each
  * of the three possible states.
  *)
-ProcessTasks(a, T) ==
-    /\ T /= {} /\ T \subseteq agentTaskAlloc[a]
+ProcessTasks(T) ==
+    /\ T /= {} /\ T \subseteq AssignedTask
     /\ \/ taskState' =
             [t \in Task |-> IF t \in T THEN TASK_SUCCEEDED ELSE taskState[t]]
        \/ taskState' =
@@ -185,7 +175,6 @@ ProcessTasks(a, T) ==
             [t \in Task |-> IF t \in T THEN TASK_FAILED ELSE taskState[t]]
        \/ taskState' =
             [t \in Task |-> IF t \in T THEN TASK_STOPPED ELSE taskState[t]]
-    /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
     /\ UNCHANGED << nextAttemptOf, stoppingRequested, pausingRequested,
                     taskDeleted >>
 
@@ -197,14 +186,14 @@ CompleteTasks(T) ==
     /\ T /= {} /\ T \subseteq SucceededTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_COMPLETED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested,
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested,
                     pausingRequested, taskDeleted >>
 
 AbortTasks(T) ==
     /\ T /= {} /\ T \subseteq DiscardedTask
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_ABORTED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested,
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested,
                     pausingRequested, taskDeleted >>
 
 RetryTasks(T) ==
@@ -212,7 +201,7 @@ RetryTasks(T) ==
     /\ T \intersect UnretriedTask = {}
     /\ taskState' =
         [t \in Task |-> IF t \in T THEN TASK_RETRIED ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested,
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested,
                     pausingRequested, taskDeleted >>
 
 (**
@@ -223,18 +212,15 @@ RequestTasksStopping(T) ==
     /\ T /= {} /\ T \intersect UnknownTask = {}
     /\ T \intersect taskDeleted = {}
     /\ stoppingRequested' = stoppingRequested \union T
-    /\ UNCHANGED << agentTaskAlloc, taskState, nextAttemptOf, pausingRequested,
+    /\ UNCHANGED << taskState, nextAttemptOf, pausingRequested,
                     taskDeleted >>
 
 (**
  * TASK CANCELLATION ACKNOWLEDGMENT
- * The request to cancel a set 'T' of tasks is acknowledged. There are two
- * possible scenarios:
- *   - All tasks in 'T' are assigned to agent 'a', in which case they are
- *     released and their states changes to STOPPED.
- *   - No tasks in 'T' is allocated and therefore all tasks are changed to
- *     the STOPPED state, provided that their processing has not already
- *     been completed (i.e., the tasks are in REGISTERED or STAGED states).
+ * The request to cancel a set 'T' of tasks is acknowledged. Tasks not
+ * currently assigned are changed to the STOPPED state, provided that their
+ * processing has not already been completed (i.e., the tasks are in
+ * REGISTERED, STAGED or PAUSED states).
  *)
 StopTasks(T) ==
     /\ T /= {}
@@ -247,7 +233,7 @@ StopTasks(T) ==
                                        \/ t \in PausedTask)
                             THEN TASK_STOPPED
                             ELSE taskState[t]]
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested,
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested,
                     pausingRequested, taskDeleted >>
 
 (**
@@ -260,26 +246,17 @@ RequestTasksPausing(T) ==
     /\ T \intersect stoppingRequested = {}
     /\ T \intersect taskDeleted = {}
     /\ pausingRequested' = pausingRequested \union T
-    /\ UNCHANGED << agentTaskAlloc, taskState, nextAttemptOf, stoppingRequested,
+    /\ UNCHANGED << taskState, nextAttemptOf, stoppingRequested,
                     taskDeleted >>
 
 (**
  * TASK PAUSING ACKNOWLEDGMENT
- * The request to pause a set 'T' of tasks is acknowledged. There are two
- * possible scenarios:
- *   - All tasks in 'T' are assigned to agent 'a', in which case they are
- *     released and their states changes to PAUSED.
- *   - No tasks in 'T' is allocated and therefore all STAGED tasks are set to
- *     the PAUSED state and the other tasks remain in the same state.
+ * The request to pause a set 'T' of tasks is acknowledged. STAGED or
+ * ASSIGNED tasks are set to the PAUSED state.
  *)
 PauseTasks(T) ==
     /\ T /= {} /\ T \subseteq pausingRequested
     /\ T \intersect taskDeleted = {}
-    /\ \/ \E a \in Agent:
-            /\ T \subseteq agentTaskAlloc[a]
-            /\ agentTaskAlloc' = [agentTaskAlloc EXCEPT ![a] = @ \ T]
-       \/ /\ T \intersect AssignedTask = {}
-          /\ UNCHANGED agentTaskAlloc
     /\ taskState' =
         [t \in Task |-> IF t \in T /\ (t \in StagedTask \/ t \in AssignedTask)
                             THEN TASK_PAUSED
@@ -300,7 +277,7 @@ ResumeTasks(T) ==
                             THEN TASK_STAGED
                             ELSE taskState[t]]
     /\ pausingRequested' = pausingRequested \ T
-    /\ UNCHANGED << agentTaskAlloc, nextAttemptOf, stoppingRequested,
+    /\ UNCHANGED << nextAttemptOf, stoppingRequested,
                     taskDeleted >>
 
 DeleteTasks(T) ==
@@ -315,12 +292,12 @@ DeleteTasks(T) ==
     /\ T \intersect pausingRequested = {}
     /\ \A t \in T: t \in RegisteredTask => ~ \E u \in Task: nextAttemptOf[u] = t
     /\ taskDeleted' = taskDeleted \union T
-    /\ UNCHANGED << agentTaskAlloc, taskState, nextAttemptOf, stoppingRequested, pausingRequested >>
+    /\ UNCHANGED << taskState, nextAttemptOf, stoppingRequested, pausingRequested >>
 
 (**
  * TERMINAL STATE
  * Action representing the terminal state of the system, reached when
- * there are no more tasks being processed (i.e., assigned to an agent or not
+ * there are no more tasks being processed (i.e., assigned or not
  * yet finalized i.e., completed, retried, aborted or canceled).
  *)
 Terminating ==
@@ -346,10 +323,9 @@ Next ==
         \/ StageTasks(T)
         \/ DiscardTasks(T)
         \/ \E U \in SUBSET Task: SetTaskRetries(T, U)
-        \/ \E a \in Agent:
-            \/ AssignTasks(a, T)
-            \/ ReleaseTasks(a, T)
-            \/ ProcessTasks(a, T)
+        \/ AssignTasks(T)
+        \/ ReleaseTasks(T)
+        \/ ProcessTasks(T)
         \/ CompleteTasks(T)
         \/ AbortTasks(T)
         \/ RetryTasks(T)
@@ -365,7 +341,7 @@ Next ==
  * FAIRNESS CONDITIONS
  * Ensure that progress is eventually made for tasks that can act.
  *   - A task cannot remain indefinitely failed without being retried.
- *   - A task cannot be assigned to an agent an infinite number of times
+ *   - A task cannot be assigned an infinite number of times
  *     without eventually being processed.
  *   - A task cannot remain indefinitely processed without being eventually
  *     finalized (completed, retried or aborted).
@@ -376,7 +352,7 @@ Fairness ==
         /\ WF_vars(\E u \in Task : SetTaskRetries({t}, {u}))
         /\ WF_vars(RegisterTasks({nextAttemptOf[t]}))
         /\ WF_vars(StageTasks({nextAttemptOf[t]}))
-        /\ SF_vars(\E a \in Agent : ProcessTasks(a, {t}))
+        /\ SF_vars(ProcessTasks({t}))
         /\ WF_vars(CompleteTasks({t}))
         /\ WF_vars(AbortTasks({t}))
         /\ WF_vars(RetryTasks({t}))

--- a/specs/TaskProcessing4_mc.cfg
+++ b/specs/TaskProcessing4_mc.cfg
@@ -1,5 +1,4 @@
 CONSTANTS
-    Agent = {a, b}
     Task = {t, u}
     NULL = ""
     MaxRetries = 1

--- a/specs/TaskStates.tla
+++ b/specs/TaskStates.tla
@@ -21,7 +21,7 @@ VARIABLE
 TASK_UNKNOWN    == "TASK_UNKNOWN"    \* Task is virtual, not yet known to the system
 TASK_REGISTERED == "TASK_REGISTERED" \* Task is known to the system and pending readiness for processing
 TASK_STAGED     == "TASK_STAGED"     \* Task is ready for processing
-TASK_ASSIGNED   == "TASK_ASSIGNED"   \* Task is assigned to an agent for processing
+TASK_ASSIGNED   == "TASK_ASSIGNED"   \* Task is assigned for processing
 TASK_PROCESSED  == "TASK_PROCESSED"  \* Task processing completed
 TASK_SUCCEEDED  == "TASK_SUCCEEDED"  \* Task processing succeeded
 TASK_FAILED     == "TASK_FAILED"     \* Task processing failed, but the task can be retried


### PR DESCRIPTION
## Summary

Remove the `Agent` abstraction from the task processing and graph processing TLA+ specifications. Tasks are no longer assigned to specific agents — they transition directly between lifecycle states (staged → assigned → processed) as sets, without tracking agent identity.

## Motivation

Agent allocation is a low-level, implementation-specific concern that does not belong in the top-level abstract specifications. These specs should capture the essential task lifecycle semantics — assignment, processing, finalization — without prescribing how assignment is realized. Binding tasks to named agents is one particular concrete implementation of task assignment, and will be reintroduced in future refinement layers where that level of detail is appropriate.

## Changes

- **TaskProcessing1–4**: Removed `Agent` constant and `assignedTo` variable. `AssignTasks` and `ReleaseTasks` now operate on sets of tasks directly instead of binding tasks to a specific agent.
- **GraphProcessing1–2**: Propagated the same simplification to graph-level task operations.
- **TaskStates / TaskRetries**: Cleaned up state definitions to reflect the removal.
- **TaskProcessing1_proofs**: Updated TLAPS proofs to match the simplified specification.
- **Model checking configs** (`TaskProcessing1.cfg`, `TaskProcessing2_mc.cfg`, etc.): Removed `Agent` constant declarations and updated state counts.
- **DenumerableSetTheorems**: Added helper lemmas (finite difference, non-emptiness) used by the updated proofs.
- **manifest.yaml**: Updated expected model checking results.

## Verification

- All TLC model checking configurations pass with updated expected state counts.
- All TLAPS proofs in `TaskProcessing1_proofs.tla` verify successfully (78 obligations, 0 omitted, 0 unproved).
- Refinement properties (each layer refines the one above) are preserved across all specification levels.