### PR TITLE
feat: add DDGraphs module for data-dependency graphs with proofs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ignore directory containing TLA+ tools
 .tla
 
+# Ignore java compiled files
+*.class
+
 # Ignore modules build directories
 modules/build/
 modules/dist/

--- a/specs/DDGraphTheorems.tla
+++ b/specs/DDGraphTheorems.tla
@@ -1,0 +1,255 @@
+------------------------- MODULE DDGraphTheorems ------------------------------
+(******************************************************************************)
+(* Foundational theorems about data-dependency graphs and their upstream-     *)
+(* derivation operators.                                                      *)
+(*                                                                            *)
+(* The structural results below revolve around AncestorSubGraph: it is a     *)
+(* subgraph of G whose every node carries a directed simple path to the      *)
+(* target n, which makes it (weakly) connected and lifts to the same          *)
+(* property on every Derivation. Together with the retry-preservation result *)
+(* these are the lemmas the higher-level specs rely on.                       *)
+(*                                                                            *)
+(* Theorems are stated here without proofs; proofs are expected to live in    *)
+(* a companion DDGraphTheorems_proofs module and to be checked with tlapm.    *)
+(******************************************************************************)
+
+EXTENDS DDGraphs, DiGraphTheorems, FiniteSets
+
+(******************************************************************************)
+(* Every member of DDGraphOf(T, O) is a DD graph over T and O, with nodes in *)
+(* T \cup O and edges in (T \X O) \cup (O \X T). The disjointness hypothesis *)
+(* T \cap O = {} is needed because DDGraphOf does not itself enforce it on   *)
+(* its (t, o) summands.                                                       *)
+(******************************************************************************)
+THEOREM DDG_DDGraphOfMember ==
+    ASSUME NEW T, NEW O, T \cap O = {},
+           NEW G \in DDGraphOf(T, O)
+    PROVE  /\ IsDDGraph(G, T, O)
+           /\ G.node \subseteq (T \cup O)
+           /\ G.edge \subseteq ((T \X O) \cup (O \X T))
+
+(******************************************************************************)
+(* Core structural properties of a DD graph G over (T, O):                    *)
+(*   - G is a well-formed directed graph and in particular a DAG;             *)
+(*   - sources and sinks of G are all objects;                                *)
+(*   - every task that occurs in G has at least one predecessor and at least *)
+(*     one successor (sources and sinks are objects, so tasks are interior); *)
+(*   - DD-graph status is preserved when extending the partitions: if T is   *)
+(*     enlarged into TT and O into OO disjointly, G remains a DD graph over  *)
+(*     (TT, OO).                                                              *)
+(******************************************************************************)
+THEOREM DDG_DDGraphProperties ==
+    ASSUME NEW T, NEW O, T \cap O = {},
+           NEW G, IsDDGraph(G, T, O)
+    PROVE  /\ IsDirectedGraph(G)
+           /\ IsDag(G)
+           /\ Source(G) \subseteq O
+           /\ Sink(G) \subseteq O
+           /\ \A t \in G.node \cap T : /\ Predecessor(G, t) /= {}
+                                       /\ Successor(G, t) /= {}
+           /\ \A TT, OO : /\ T \subseteq TT
+                          /\ O \subseteq OO
+                          /\ TT \cap OO = {}
+                          => IsDDGraph(G, TT, OO)
+
+(******************************************************************************)
+(* The empty graph is a DD graph over any disjoint partition. Together with   *)
+(* DDG_DDGraphOfMember this pins down the "trivial" member of DDGraphOf.     *)
+(******************************************************************************)
+THEOREM DDG_EmptyGraphIsDDGraph ==
+    ASSUME NEW T, NEW O, T \cap O = {}
+    PROVE  IsDDGraph(EmptyGraph, T, O)
+
+--------------------------------------------------------------------------------
+
+(******************************************************************************)
+(* Bipartite-neighborhood law for a DD graph: every neighbor of a node lies  *)
+(* in the opposite partition. A task's predecessors and successors are       *)
+(* objects, and an object's predecessors and successors are tasks. Direct    *)
+(* consequence of bipartiteness (T, O) combined with the partition           *)
+(* membership of the central node.                                            *)
+(******************************************************************************)
+LEMMA DDG_BipartiteNeighborhood ==
+    ASSUME NEW T, NEW O, T \cap O = {},
+           NEW G, IsDDGraph(G, T, O),
+           NEW n \in G.node
+    PROVE  /\ n \in T => /\ Predecessor(G, n) \subseteq O
+                         /\ Successor(G, n) \subseteq O
+           /\ n \in O => /\ Predecessor(G, n) \subseteq T
+                         /\ Successor(G, n) \subseteq T
+
+(******************************************************************************)
+(* A simple path of G whose every node satisfies Op lifts to a simple path  *)
+(* of the Op-induced subgraph H: H retains exactly the Op-satisfying nodes  *)
+(* and the edges of G between them. The lift follows from DG_SimplePathLift *)
+(* once we observe that every node and every consecutive edge of the path is *)
+(* in H.                                                                       *)
+(******************************************************************************)
+LEMMA DDG_PathLiftToOpInduced ==
+    ASSUME NEW G, IsDirectedGraph(G), NEW Op(_),
+           NEW p \in SimplePath(G),
+           \A i \in 1..Len(p) : Op(p[i])
+    PROVE  LET InducedNodes == {y \in G.node : Op(y)}
+               H == [node |-> InducedNodes,
+                     edge |-> G.edge \cap (InducedNodes \X InducedNodes)]
+           IN  p \in SimplePath(H)
+
+--------------------------------------------------------------------------------
+
+(******************************************************************************)
+(* OpenPath is empty iff the target itself fails the predicate Op: every     *)
+(* open path ends at n, so if Op(n) holds the singleton path <<n>> already   *)
+(* belongs to OpenPath; conversely no open path can end at a node that does  *)
+(* not satisfy Op.                                                            *)
+(******************************************************************************)
+THEOREM DDG_OpenPathEmpty ==
+    ASSUME NEW T, NEW O, T \cap O = {},
+           NEW G, IsDDGraph(G, T, O), NEW n \in G.node, NEW Op(_)
+    PROVE  OpenPath(G, n, Op) = {} <=> ~Op(n)
+
+--------------------------------------------------------------------------------
+
+(******************************************************************************)
+(* AncestorSubGraph — structural lemmas.                                      *)
+(*                                                                            *)
+(* The following block builds up the path-to-target property step by step,    *)
+(* which in turn yields weak connectedness. Each lemma carries the minimal    *)
+(* hypotheses on G under which it holds.                                      *)
+(******************************************************************************)
+
+(******************************************************************************)
+(* Bundled structural properties of AncestorSubGraph(G, n, Op), requiring    *)
+(* n \in O, finiteness, and Op-monotonicity (open tasks have open inputs):    *)
+(*   - it is itself a DD graph over (T, O) and a directed subgraph of G;     *)
+(*   - it is weakly connected (every pair of nodes connects through n in    *)
+(*     the underlying undirected view);                                       *)
+(*   - every retained node satisfies Op;                                     *)
+(*   - every retained node has a directed simple path to n that stays inside *)
+(*     the subgraph -- the "closure under suffixes" property.                *)
+(******************************************************************************)
+THEOREM DDG_AncestorSubGraphProperties ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+           NEW n \in O, NEW Op(_),
+           \A t \in G.node \cap T : Op(t) => \A x \in Predecessor(G, t) : Op(x)
+    PROVE  LET A == AncestorSubGraph(G, n, Op) IN
+           /\ IsDDGraph(A, T, O)
+           /\ A \in DirectedSubgraph(G)
+           /\ IsWeaklyConnected(A)
+           /\ \A m \in A.node : Op(m)
+           /\ \A m \in A.node : AreConnectedIn(A, m, n)
+
+(******************************************************************************)
+(* Maximality of AncestorSubGraph: every Op-satisfying predecessor of a node *)
+(* in A is already in A. Equivalently, the only predecessors A omits are     *)
+    (* nodes that fail Op -- A is closed under "Op-passing" upstream traversal.  *)
+(******************************************************************************)
+THEOREM DDG_AncestorSubGraphIsMaximal ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+           NEW n, NEW Op(_)
+    PROVE  LET A == AncestorSubGraph(G, n, Op) IN
+           \A m \in A.node : \A x \in Predecessor(G, m) \ A.node : ~Op(x)
+
+(******************************************************************************)
+(* Triviality characterization: AncestorSubGraph is empty iff the target n   *)
+(* itself fails Op, and n belongs to A iff Op(n) holds. The two facts are   *)
+(* duals of the same condition Op(n). Requires n \in G.node and finiteness   *)
+(* of G.node (to lift reflexivity of Ancestor through the induced subgraph). *)
+(******************************************************************************)
+THEOREM DDG_AncestorSubGraphEmpty ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+           NEW n \in G.node, NEW Op(_)
+    PROVE  LET A == AncestorSubGraph(G, n, Op) IN
+           /\ A = EmptyGraph <=> ~Op(n)
+           /\ n \in A.node <=> Op(n)
+
+(******************************************************************************)
+(* OpenSubGraph and AncestorSubGraph define the same object: the set of      *)
+(* start nodes of open paths ending at n coincides with the set of n's      *)
+(* ancestors in the Op-induced subgraph, and both pin down the same edges.   *)
+(* This lets later proofs switch between the path-based and closure-based   *)
+(* views at will.                                                            *)
+(******************************************************************************)
+THEOREM DDG_OpenSubGraphEqualsAncestorSubGraph ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O), NEW n, NEW Op(_),
+           IsFiniteSet(G.node)
+    PROVE  OpenSubGraph(G, n, Op) = AncestorSubGraph(G, n, Op)
+
+--------------------------------------------------------------------------------
+(******************************************************************************)
+(* RetrySubGraph — retry attachment is safe.                                  *)
+(******************************************************************************)
+
+(******************************************************************************)
+(* Attaching the retry of t under a fresh node u preserves acyclicity: any   *)
+(* directed cycle of GraphUnion(G, RetrySubGraph(G, t, u)) maps to a cycle of *)
+(* G by substituting u with t (u inherits exactly t's neighborhood), which   *)
+(* contradicts IsDag(G).                                                      *)
+(******************************************************************************)
+THEOREM DDG_RetryUnionIsDag ==
+    ASSUME NEW G, IsDag(G), NEW t \in G.node, NEW u, u \notin G.node
+    PROVE  IsDag(GraphUnion(G, RetrySubGraph(G, t, u)))
+
+(******************************************************************************)
+(* Retry attachment is safe and well-typed:                                   *)
+(*   - the retry subgraph R is a DD graph in which u takes the role of a    *)
+(*     task and inherits t's object neighborhood;                            *)
+(*   - R is weakly connected (u is a hub: predecessors reach u, u reaches    *)
+(*     successors);                                                          *)
+(*   - GraphUnion(G, R) is a DD graph over (T \cup {u}, O): u joins the task *)
+(*     partition without breaking bipartiteness or acyclicity (the fresh-    *)
+(*     ness of u rules out any new cycle through it).                        *)
+(******************************************************************************)
+THEOREM DDG_RetrySubGraphProperties ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+           NEW Op(_), NEW t \in T \cap G.node, NEW u, u \notin (T \cup O)
+    PROVE  LET R == RetrySubGraph(G, t, u) IN
+           /\ IsDDGraph(R, {u}, O)
+           /\ IsWeaklyConnected(R)
+           /\ IsDDGraph(GraphUnion(G, R), T \cup {u}, O)
+
+--------------------------------------------------------------------------------
+(******************************************************************************)
+(* Derivation — structural lemmas.                                            *)
+(******************************************************************************)
+
+(******************************************************************************)
+(* Lightweight structural facts about AncestorSubGraph that need only         *)
+(* well-formedness of G (no finiteness, n \in O, or Op-monotonicity): it is a *)
+(* directed subgraph of G and all its nodes satisfy Op.                       *)
+(******************************************************************************)
+THEOREM DDG_AncestorSubGraphBasic ==
+    ASSUME NEW G, IsDirectedGraph(G), NEW n, NEW Op(_)
+    PROVE  LET A == AncestorSubGraph(G, n, Op) IN
+           /\ A \in DirectedSubgraph(G)
+           /\ A.node \subseteq {y \in G.node : Op(y)}
+
+(******************************************************************************)
+(* Bundled properties of any derivation D of n in G under Op, T:              *)
+(*   - D is itself a DD graph over (T, O) (it inherits structure from G);    *)
+(*   - D is weakly connected (all its nodes reach n through directed paths   *)
+(*     that stay inside D);                                                   *)
+(*   - every node of D satisfies Op (D \subseteq AncestorSubGraph);          *)
+(*   - every node of D carries a directed simple path to n inside D.         *)
+(******************************************************************************)
+THEOREM DDG_DerivationProperties ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O), IsFiniteSet(G.node),
+           NEW n \in O, NEW Op(_), NEW D \in Derivation(G, n, Op, T)
+    PROVE  /\ IsDDGraph(D, T, O)
+           /\ IsWeaklyConnected(D)
+           /\ \A m \in D.node : Op(m)
+           /\ \A m \in D.node : AreConnectedIn(D, m, n)
+
+(******************************************************************************)
+(* Non-existence criterion: if no derivation of n exists, then some ancestor *)
+(* of n fails Op. Contrapositively, if every ancestor of n satisfies Op then *)
+(* the ancestor-induced subgraph of n is itself a derivation. (Note: a       *)
+(* "clean simple path" to n is NOT sufficient for a derivation, because a    *)
+(* task needs ALL of its inputs Op, not just the one on the path -- hence    *)
+(* the criterion quantifies over all ancestors, not over a single path.)     *)
+(******************************************************************************)
+THEOREM DDG_NoDerivationMeansBlockedAncestor ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+           NEW n \in G.node, NEW Op(_)
+    PROVE  Derivation(G, n, Op, T) = {} => \E m \in Ancestor(G, n) : ~Op(m)
+
+================================================================================

--- a/specs/DDGraphTheorems_proofs.tla
+++ b/specs/DDGraphTheorems_proofs.tla
@@ -1,0 +1,1098 @@
+---------------------- MODULE DDGraphTheorems_proofs --------------------------
+(******************************************************************************)
+(* Proofs of the theorems declared in DDGraphTheorems. Checked with tlapm.   *)
+(*                                                                            *)
+(* Most structural results below ultimately rely on path-level reasoning      *)
+(* about AncestorSubGraph and on the bipartite shape of a DD graph; the      *)
+(* deeper arguments (weak connectivity, AncestorSubGraph maximality,         *)
+(* derivation properties) are admitted with PROOF OMITTED and will be        *)
+(* discharged in a follow-up pass.                                            *)
+(******************************************************************************)
+
+EXTENDS DDGraphs, DiGraphTheorems, FiniteSetTheorems, FiniteSetsExtTheorems,
+        FunctionTheorems, SequenceTheorems, TLAPS
+
+(******************************************************************************)
+(* Every member of DDGraphOf(T, O) is a DD graph over T and O, with nodes in *)
+(* T \cup O and edges in (T \X O) \cup (O \X T). The disjointness hypothesis *)
+(* T \cap O = {} is needed because DDGraphOf does not itself enforce it on   *)
+(* its (t, o) summands.                                                       *)
+(******************************************************************************)
+THEOREM DDG_DDGraphOfMember ==
+    ASSUME NEW T, NEW O, T \cap O = {},
+           NEW G \in DDGraphOf(T, O)
+    PROVE  /\ IsDDGraph(G, T, O)
+           /\ G.node \subseteq (T \cup O)
+           /\ G.edge \subseteq ((T \X O) \cup (O \X T))
+BY DEF DDGraphOf, IsDDGraph, IsBipartiteWithPartitions
+
+(******************************************************************************)
+(* Core structural properties of a DD graph. The directed-graph,             *)
+(* DAG-and-source/sink facts unfold from the definitions; subgraph and       *)
+(* partition-enlargement preservation follow from monotonicity of IsDDGraph; *)
+(* the task-has-neighbors fact requires the bipartite structure plus the     *)
+(* sources/sinks-are-objects constraint.                                     *)
+(******************************************************************************)
+THEOREM DDG_DDGraphProperties ==
+    ASSUME NEW T, NEW O, T \cap O = {},
+           NEW G, IsDDGraph(G, T, O)
+    PROVE  /\ IsDirectedGraph(G)
+           /\ IsDag(G)
+           /\ Source(G) \subseteq O
+           /\ Sink(G) \subseteq O
+           /\ \A t \in G.node \cap T : /\ Predecessor(G, t) /= {}
+                                       /\ Successor(G, t) /= {}
+           /\ \A TT, OO : /\ T \subseteq TT
+                          /\ O \subseteq OO
+                          /\ TT \cap OO = {}
+                          => IsDDGraph(G, TT, OO)
+<1>1. IsDag(G) /\ Source(G) \subseteq O /\ Sink(G) \subseteq O
+    BY DEF IsDDGraph
+<1>2. IsDirectedGraph(G)
+    BY <1>1, DG_DagProperties
+<1>3. IsBipartiteWithPartitions(G, T, O)
+    BY DEF IsDDGraph
+<1>4. \A t \in G.node \cap T : Predecessor(G, t) /= {} /\ Successor(G, t) /= {}
+    <2> SUFFICES ASSUME NEW t \in G.node \cap T
+                 PROVE  Predecessor(G, t) /= {} /\ Successor(G, t) /= {}
+        OBVIOUS
+    <2>1. t \notin O
+        OBVIOUS
+    <2>2. t \notin Source(G)
+        BY <2>1, <1>1
+    <2>3. t \notin Sink(G)
+        BY <2>1, <1>1
+    <2>4. Predecessor(G, t) /= {}
+        BY <2>2 DEF Source
+    <2>5. Successor(G, t) /= {}
+        BY <2>3 DEF Sink
+    <2>. QED
+        BY <2>4, <2>5
+<1>5. \A TT, OO : /\ T \subseteq TT
+                  /\ O \subseteq OO
+                  /\ TT \cap OO = {}
+                  => IsDDGraph(G, TT, OO)
+    <2> SUFFICES ASSUME NEW TT, NEW OO,
+                        T \subseteq TT, O \subseteq OO, TT \cap OO = {}
+                 PROVE  IsDDGraph(G, TT, OO)
+        OBVIOUS
+    <2>1. G.node \subseteq T \cup O
+        BY <1>3 DEF IsBipartiteWithPartitions
+    <2>2. G.node \subseteq TT \cup OO
+        BY <2>1
+    <2>3. \A e \in G.edge :
+              \/ e[1] \in TT /\ e[2] \in OO
+              \/ e[2] \in TT /\ e[1] \in OO
+        BY <1>3 DEF IsBipartiteWithPartitions
+    <2>4. IsBipartiteWithPartitions(G, TT, OO)
+        BY <2>2, <2>3 DEF IsBipartiteWithPartitions
+    <2>5. Source(G) \subseteq OO /\ Sink(G) \subseteq OO
+        BY <1>1
+    <2>. QED
+        BY <2>4, <2>5, <1>1 DEF IsDDGraph
+<1>. QED
+    BY <1>1, <1>2, <1>4, <1>5
+
+(******************************************************************************)
+(* The empty graph is trivially a DD graph: it is a DAG, vacuously bipartite *)
+(* over any disjoint partition, and has neither sources nor sinks.            *)
+(******************************************************************************)
+THEOREM DDG_EmptyGraphIsDDGraph ==
+    ASSUME NEW T, NEW O, T \cap O = {}
+    PROVE  IsDDGraph(EmptyGraph, T, O)
+BY DG_EmptyGraphProperties DEF IsDDGraph
+
+--------------------------------------------------------------------------------
+(******************************************************************************)
+(* Helper lemmas used across the DD-graph proofs.                             *)
+(******************************************************************************)
+
+(******************************************************************************)
+(* Bipartite-neighborhood law for a DD graph: every neighbor of a node lies  *)
+(* in the opposite partition. A task's neighbors are objects, and an         *)
+(* object's neighbors are tasks. Direct consequence of bipartiteness (T, O)  *)
+(* combined with the central node's partition membership. Consumed by       *)
+(* DDG_RetrySubGraphProperties (via the task case).                          *)
+(******************************************************************************)
+LEMMA DDG_BipartiteNeighborhood ==
+    ASSUME NEW T, NEW O, T \cap O = {},
+           NEW G, IsDDGraph(G, T, O),
+           NEW n \in G.node
+    PROVE  /\ n \in T => /\ Predecessor(G, n) \subseteq O
+                         /\ Successor(G, n) \subseteq O
+           /\ n \in O => /\ Predecessor(G, n) \subseteq T
+                         /\ Successor(G, n) \subseteq T
+<1>1. IsBipartiteWithPartitions(G, T, O)
+    BY DEF IsDDGraph
+<1>2. ASSUME n \in T
+      PROVE  Predecessor(G, n) \subseteq O /\ Successor(G, n) \subseteq O
+    <2>1. n \notin O
+        BY <1>2
+    <2>2. Predecessor(G, n) \subseteq O
+        <3> SUFFICES ASSUME NEW p \in Predecessor(G, n) PROVE p \in O
+            OBVIOUS
+        <3>1. <<p, n>> \in G.edge
+            BY DEF Predecessor
+        <3>. QED
+            BY <3>1, <1>1, <2>1 DEF IsBipartiteWithPartitions
+    <2>3. Successor(G, n) \subseteq O
+        <3> SUFFICES ASSUME NEW s \in Successor(G, n) PROVE s \in O
+            OBVIOUS
+        <3>1. <<n, s>> \in G.edge
+            BY DEF Successor
+        <3>. QED
+            BY <3>1, <1>1, <2>1 DEF IsBipartiteWithPartitions
+    <2>. QED
+        BY <2>2, <2>3
+<1>3. ASSUME n \in O
+      PROVE  Predecessor(G, n) \subseteq T /\ Successor(G, n) \subseteq T
+    <2>1. n \notin T
+        BY <1>3
+    <2>2. Predecessor(G, n) \subseteq T
+        <3> SUFFICES ASSUME NEW p \in Predecessor(G, n) PROVE p \in T
+            OBVIOUS
+        <3>1. <<p, n>> \in G.edge
+            BY DEF Predecessor
+        <3>. QED
+            BY <3>1, <1>1, <2>1 DEF IsBipartiteWithPartitions
+    <2>3. Successor(G, n) \subseteq T
+        <3> SUFFICES ASSUME NEW s \in Successor(G, n) PROVE s \in T
+            OBVIOUS
+        <3>1. <<n, s>> \in G.edge
+            BY DEF Successor
+        <3>. QED
+            BY <3>1, <1>1, <2>1 DEF IsBipartiteWithPartitions
+    <2>. QED
+        BY <2>2, <2>3
+<1>. QED
+    BY <1>2, <1>3
+
+(******************************************************************************)
+(* A simple path of G whose every node satisfies Op lifts to a simple path  *)
+(* of the Op-induced subgraph H: H retains exactly the Op-satisfying nodes  *)
+(* and the edges of G between them. The lift follows directly from         *)
+(* DG_SimplePathLift once we observe that every node of the path is in     *)
+(* H.node and every consecutive edge is in H.edge.                          *)
+(******************************************************************************)
+LEMMA DDG_PathLiftToOpInduced ==
+    ASSUME NEW G, IsDirectedGraph(G), NEW Op(_),
+           NEW p \in SimplePath(G),
+           \A i \in 1..Len(p) : Op(p[i])
+    PROVE  LET InducedNodes == {y \in G.node : Op(y)}
+               H == [node |-> InducedNodes,
+                     edge |-> G.edge \cap (InducedNodes \X InducedNodes)]
+           IN  p \in SimplePath(H)
+<1> DEFINE InducedNodes == {y \in G.node : Op(y)}
+<1> DEFINE H == [node |-> InducedNodes,
+                 edge |-> G.edge \cap (InducedNodes \X InducedNodes)]
+<1>1. /\ p \in Seq(G.node) /\ p # << >>
+      /\ Len(p) \in Nat /\ Len(p) >= 1 /\ DOMAIN p = 1..Len(p)
+      /\ \A i \in 1..(Len(p) - 1) : <<p[i], p[i+1]>> \in G.edge
+    BY DG_SimplePathIsSeq
+<1>2. \A i \in 1..Len(p) : p[i] \in InducedNodes
+    <2> SUFFICES ASSUME NEW i \in 1..Len(p) PROVE p[i] \in InducedNodes
+        OBVIOUS
+    <2>1. p[i] \in G.node /\ Op(p[i])
+        BY <1>1, ElementOfSeq
+    <2>. QED
+        BY <2>1
+<1>3. \A i \in 1..Len(p) : p[i] \in H.node
+    BY <1>2
+<1>4. \A i \in 1..(Len(p) - 1) : <<p[i], p[i+1]>> \in H.edge
+    <2> SUFFICES ASSUME NEW i \in 1..(Len(p) - 1)
+                 PROVE  <<p[i], p[i+1]>> \in H.edge
+        OBVIOUS
+    <2>1. <<p[i], p[i+1]>> \in G.edge
+        BY <1>1
+    <2>2. i \in 1..Len(p) /\ i+1 \in 1..Len(p)
+        BY <1>1
+    <2>3. p[i] \in InducedNodes /\ p[i+1] \in InducedNodes
+        BY <2>2, <1>2
+    <2>. QED
+        BY <2>1, <2>3
+<1>. QED
+    BY <1>3, <1>4, DG_SimplePathLift
+
+--------------------------------------------------------------------------------
+(******************************************************************************)
+(* OpenPath, AncestorSubGraph, RetrySubGraph and Derivation theorems.        *)
+(******************************************************************************)
+
+THEOREM DDG_OpenPathEmpty ==
+    ASSUME NEW T, NEW O, T \cap O = {},
+           NEW G, IsDDGraph(G, T, O), NEW n \in G.node, NEW Op(_)
+    PROVE  OpenPath(G, n, Op) = {} <=> ~Op(n)
+<1>1. OpenPath(G, n, Op) = {} => ~Op(n)
+    <2>. SUFFICES ASSUME OpenPath(G, n, Op) = {}, Op(n)
+                  PROVE FALSE
+        OBVIOUS
+    <2>1. <<n>> \in SimplePath(G)
+        BY DG_TrivialPath, DDG_DDGraphProperties
+    <2>. QED
+        BY <2>1 DEF OpenPath
+<1>2. ~Op(n) => OpenPath(G, n, Op) = {}
+    <2>. SUFFICES ASSUME ~Op(n), OpenPath(G, n, Op) /= {}
+                  PROVE FALSE
+        OBVIOUS
+    <2>1. PICK p \in SimplePath(G) :
+              p[Len(p)] = n /\ \A i \in 1..Len(p) : Op(p[i])
+        BY DEF OpenPath
+    <2>4. p \in Seq(G.node) /\ Len(p) \in Nat /\ Len(p) >= 1 /\ DOMAIN p = 1..Len(p)
+        BY <2>1, DG_SimplePathIsSeq
+    <2>5. Len(p) \in 1..Len(p)
+        BY <2>4
+    <2>. QED
+        BY <2>1, <2>5
+<1>. QED
+    BY <1>1, <1>2
+
+THEOREM DDG_AncestorSubGraphProperties ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+           NEW n \in O, NEW Op(_),
+           \A t \in G.node \cap T : Op(t) => \A x \in Predecessor(G, t) : Op(x)
+    PROVE  LET A == AncestorSubGraph(G, n, Op) IN
+           /\ IsDDGraph(A, T, O)
+           /\ A \in DirectedSubgraph(G)
+           /\ IsWeaklyConnected(A)
+           /\ \A m \in A.node : Op(m)
+           /\ \A m \in A.node : AreConnectedIn(A, m, n)
+<1> DEFINE InducedNodes == {y \in G.node : Op(y)}
+<1> DEFINE InducedGraph == [node |-> InducedNodes,
+                            edge |-> G.edge \cap (InducedNodes \X InducedNodes)]
+<1> DEFINE N == IF n \in InducedNodes
+                THEN Ancestor(InducedGraph, n)
+                ELSE {}
+<1> DEFINE A == AncestorSubGraph(G, n, Op)
+(* Setup: G is a DAG, A is the InducedGraph-ancestor subgraph of n in G *)
+<1>1. /\ IsDirectedGraph(G) /\ IsDag(G) /\ T \cap O = {} /\ G.node \subseteq T \cup O
+      /\ Source(G) \subseteq O /\ Sink(G) \subseteq O
+    BY DEF IsDDGraph, IsDag, IsBipartiteWithPartitions
+<1>2. IsDirectedGraph(InducedGraph) /\ InducedGraph.node = InducedNodes
+      /\ InducedNodes \subseteq G.node
+    BY DEF IsDirectedGraph
+<1>3. /\ A = [node |-> N, edge |-> G.edge \cap (N \X N)]
+      /\ A.node = N /\ A.edge = G.edge \cap (N \X N)
+      /\ N \subseteq InducedNodes
+      /\ A.node \subseteq InducedNodes /\ A.node \subseteq G.node
+      /\ A.edge \subseteq G.edge
+    <2>1. A = [node |-> N, edge |-> G.edge \cap (N \X N)]
+        BY DEF AncestorSubGraph
+    <2>2. A.node = N /\ A.edge = G.edge \cap (N \X N)
+        <3> HIDE DEF A, N, InducedGraph, InducedNodes
+        <3> QED
+            BY <2>1
+    <2>3. N \subseteq InducedNodes
+        BY <1>2 DEF Ancestor
+    <2>. QED
+        BY <2>1, <2>2, <2>3, <1>2
+(* Conjunct 4: every node of A satisfies Op *)
+<1>4. \A m \in A.node : Op(m)
+    BY <1>3
+(* Conjunct 2: A is a directed subgraph of G *)
+<1>5. A \in DirectedSubgraph(G)
+    <2>1. A.node \in SUBSET G.node /\ A.edge \in SUBSET (G.node \X G.node)
+        BY <1>3, <1>1 DEF IsDirectedGraph
+    <2>2. IsDirectedGraph(A)
+        <3> HIDE DEF A, N, InducedGraph, InducedNodes
+        <3> QED
+            BY <1>3 DEF IsDirectedGraph
+    <2>. QED
+        BY <2>1, <2>2, <1>3 DEF DirectedSubgraph
+(* Conjunct 5: every node of A reaches n inside A, via path-lift through InducedGraph *)
+<1>6. \A m \in A.node : AreConnectedIn(A, m, n)
+    <2> SUFFICES ASSUME NEW m \in A.node PROVE AreConnectedIn(A, m, n)
+        OBVIOUS
+    <2>1. N # {} /\ n \in InducedNodes /\ N = Ancestor(InducedGraph, n)
+        BY <1>3
+    <2>2. m \in Ancestor(InducedGraph, n)
+        BY <1>3, <2>1
+    <2>3. PICK p \in SimplePath(InducedGraph) : p[1] = m /\ p[Len(p)] = n
+        BY <2>2 DEF Ancestor, AreConnectedIn
+    <2>4. \A i \in 1..Len(p) : p[i] \in Ancestor(InducedGraph, n)
+        <3> SUFFICES ASSUME NEW i \in 1..Len(p)
+                     PROVE  p[i] \in Ancestor(InducedGraph, n)
+            OBVIOUS
+        <3>1. p[i] \in Ancestor(InducedGraph, p[Len(p)])
+            BY <2>3, <1>2, DG_AncestorOnPath
+        <3>. QED
+            BY <3>1, <2>3
+    <2>5. \A i \in 1..Len(p) : p[i] \in A.node
+        BY <2>4, <1>3, <2>1
+    <2>6. \A i \in 1..(Len(p) - 1) : <<p[i], p[i+1]>> \in A.edge
+        <3> SUFFICES ASSUME NEW i \in 1..(Len(p) - 1)
+                     PROVE  <<p[i], p[i+1]>> \in A.edge
+            OBVIOUS
+        <3>1. i \in 1..Len(p) /\ i+1 \in 1..Len(p)
+            BY <2>3, DG_SimplePathIsSeq
+        <3>2. <<p[i], p[i+1]>> \in InducedGraph.edge
+            BY <2>3, DG_SimplePathIsSeq
+        <3>3. p[i] \in A.node /\ p[i+1] \in A.node
+            BY <3>1, <2>5
+        <3>. QED
+            BY <3>2, <3>3, <1>3
+    <2>7. p \in SimplePath(A)
+        BY <2>3, <2>5, <2>6, DG_SimplePathLift
+    <2>. QED
+        BY <2>3, <2>7 DEF AreConnectedIn
+(* Conjunct 1: A is a DD graph over (T, O) *)
+<1>7. IsDDGraph(A, T, O)
+    <2>1. IsBipartiteWithPartitions(G, T, O)
+        BY DEF IsDDGraph
+    <2>2. IsDag(A) /\ IsBipartiteWithPartitions(A, T, O)
+        BY <1>5, <1>1, <2>1, DG_DirectedSubgraphProperties
+    <2>3. Source(A) \subseteq O
+        <3> SUFFICES ASSUME NEW s \in Source(A), s \in T PROVE FALSE
+            BY <1>3, <1>1 DEF Source
+        <3>1. s \in A.node /\ Predecessor(A, s) = {}
+            BY DEF Source
+        <3>2. s \in G.node \cap T /\ Op(s)
+            BY <3>1, <1>3
+        <3>3. PICK x \in Predecessor(G, s) : TRUE
+            BY <3>2, <1>1, DDG_DDGraphProperties
+        <3>4. <<x, s>> \in G.edge /\ x \in G.node /\ Op(x)
+            BY <3>2, <3>3, <1>1 DEF Predecessor, IsDirectedGraph
+        <3>5. x \in InducedNodes /\ s \in InducedNodes
+            BY <3>4, <3>1, <1>3
+        <3>6. <<x, s>> \in InducedGraph.edge
+            BY <3>4, <3>5
+        <3>7. s \in Ancestor(InducedGraph, n)
+            BY <3>1, <1>3
+        <3>8. x \in Ancestor(InducedGraph, n)
+            BY <3>6, <3>7, <1>2, DG_AncestorClosedUnderPredecessor
+        <3>9. x \in A.node /\ <<x, s>> \in A.edge
+            BY <3>8, <1>3, <3>4, <3>1
+        <3>. QED
+            BY <3>9, <3>1 DEF Predecessor
+    <2>4. Sink(A) \subseteq O
+        <3> SUFFICES ASSUME NEW s \in Sink(A), s # n PROVE s \in O
+            BY <1>3, <1>1 DEF Sink
+        <3>1. s \in A.node
+            BY DEF Sink
+        <3>2. AreConnectedIn(A, s, n)
+            BY <3>1, <1>6
+        <3>3. PICK p \in SimplePath(A) : p[1] = s /\ p[Len(p)] = n
+            BY <3>2 DEF AreConnectedIn
+        <3>4. /\ p \in Seq(A.node) /\ Len(p) \in Nat /\ Len(p) >= 1
+              /\ \A i \in 1..(Len(p) - 1) : <<p[i], p[i+1]>> \in A.edge
+            BY <3>3, DG_SimplePathIsSeq
+        <3>5. Len(p) >= 2
+            <4>1. SUFFICES Len(p) # 1 BY <3>4
+            <4>. QED
+                BY <3>3, <3>4
+        <3>6. 1 \in 1..(Len(p) - 1) /\ 2 \in 1..Len(p)
+            BY <3>4, <3>5
+        <3>7. <<s, p[2]>> \in A.edge /\ p[2] \in A.node
+            BY <3>3, <3>6, <3>4, ElementOfSeq
+        <3>. QED
+            BY <3>7, <3>1 DEF Sink, Successor
+    <2>. QED
+        BY <2>2, <2>3, <2>4 DEF IsDDGraph
+(* Conjunct 3: A is weakly connected (vacuous when empty, else hub at n) *)
+<1>8. IsWeaklyConnected(A)
+    <2>1. CASE A.node = {}
+        BY <2>1 DEF IsWeaklyConnected
+    <2>2. CASE A.node # {}
+        <3>1. n \in InducedGraph.node /\ N = Ancestor(InducedGraph, n)
+            BY <2>2, <1>3, <1>2
+        <3>2. n \in Ancestor(InducedGraph, n)
+            BY <3>1, <1>2, DG_AncestorDescendantProperties
+        <3>3. n \in A.node /\ IsDirectedGraph(A)
+            BY <3>1, <3>2, <1>3, <1>5 DEF DirectedSubgraph
+        <3>. QED
+            BY <3>3, <1>6, DG_WeaklyConnectedViaHub
+    <2>. QED
+        BY <2>1, <2>2
+<1>. QED
+    BY <1>7, <1>5, <1>8, <1>4, <1>6
+
+THEOREM DDG_AncestorSubGraphIsMaximal ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+           NEW n, NEW Op(_)
+    PROVE  LET A == AncestorSubGraph(G, n, Op) IN
+           \A m \in A.node : \A x \in Predecessor(G, m) \ A.node : ~Op(x)
+<1> DEFINE InducedNodes == {y \in G.node : Op(y)}
+<1> DEFINE InducedGraph == [node |-> InducedNodes,
+                            edge |-> G.edge \cap (InducedNodes \X InducedNodes)]
+<1> DEFINE N == IF n \in InducedNodes THEN Ancestor(InducedGraph, n) ELSE {}
+<1> DEFINE A == AncestorSubGraph(G, n, Op)
+<1>1. A = [node |-> N, edge |-> G.edge \cap (N \X N)]
+    BY DEF AncestorSubGraph
+<1>2. A.node = N
+    BY <1>1
+<1>3. SUFFICES ASSUME NEW m \in A.node,
+                      NEW x \in Predecessor(G, m) \ A.node,
+                      Op(x)
+               PROVE  FALSE
+    OBVIOUS
+<1>4. m \in N
+    BY <1>2
+<1>5. N # {}
+    BY <1>4
+<1>6. n \in InducedNodes
+    BY <1>5
+<1>7. m \in Ancestor(InducedGraph, n)
+    BY <1>4, <1>6
+<1>8. IsDirectedGraph(G)
+    BY DEF IsDDGraph, IsDag
+<1>9. <<x, m>> \in G.edge /\ x \in G.node /\ m \in G.node
+    BY <1>3, <1>8 DEF Predecessor, IsDirectedGraph
+<1>10. x \in InducedNodes
+    BY <1>9, <1>3
+<1>11. m \in InducedNodes
+    <2>1. m \in Ancestor(InducedGraph, n)
+        BY <1>7
+    <2>2. Ancestor(InducedGraph, n) \subseteq InducedGraph.node
+        BY DEF Ancestor
+    <2>. QED
+        BY <2>1, <2>2
+<1>12. <<x, m>> \in InducedGraph.edge
+    BY <1>9, <1>10, <1>11
+<1>13. IsDirectedGraph(InducedGraph)
+    <2>1. InducedGraph.edge \subseteq InducedGraph.node \X InducedGraph.node
+        OBVIOUS
+    <2>. QED
+        BY <2>1 DEF IsDirectedGraph
+<1>15. x \in Ancestor(InducedGraph, n)
+    BY <1>13, <1>12, <1>7, DG_AncestorClosedUnderPredecessor
+<1>16. x \in N
+    BY <1>15, <1>6
+<1>17. x \in A.node
+    BY <1>16, <1>2
+<1>. QED
+    BY <1>17, <1>3
+
+THEOREM DDG_AncestorSubGraphEmpty ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+           NEW n \in G.node, NEW Op(_)
+    PROVE  LET A == AncestorSubGraph(G, n, Op) IN
+           /\ A = EmptyGraph <=> ~Op(n)
+           /\ n \in A.node <=> Op(n)
+<1> DEFINE InducedNodes == {m \in G.node : Op(m)}
+<1> DEFINE InducedGraph == [node |-> InducedNodes,
+                            edge |-> G.edge \cap (InducedNodes \X InducedNodes)]
+<1> DEFINE N == IF n \in InducedNodes
+                THEN Ancestor(InducedGraph, n)
+                ELSE {}
+<1> DEFINE A == AncestorSubGraph(G, n, Op)
+<1>1. A = [node |-> N, edge |-> G.edge \cap (N \X N)]
+    BY DEF AncestorSubGraph
+<1>4. InducedGraph.node = InducedNodes
+    OBVIOUS
+<1>5. CASE ~Op(n)
+    <2>1. n \notin InducedNodes
+        BY <1>5
+    <2>2. N = {}
+        BY <2>1
+    <2>3. A = [node |-> {}, edge |-> {}]
+        <3>1. G.edge \cap ({} \X {}) = {}
+            OBVIOUS
+        <3>. QED
+            BY <1>1, <2>2, <3>1
+    <2>4. A = EmptyGraph
+        BY <2>3 DEF EmptyGraph
+    <2>5. n \notin A.node
+        BY <1>1, <2>2
+    <2>. QED
+        BY <1>5, <2>4, <2>5
+<1>6. CASE Op(n)
+    <2>1. n \in InducedNodes
+        BY <1>6
+    <2>2. N = Ancestor(InducedGraph, n)
+        BY <2>1
+    <2>3. n \in N
+        <3>1. n \in InducedGraph.node
+            BY <2>1
+        <3>2. n \in Ancestor(InducedGraph, n)
+            BY <3>1, <1>4, DG_AncestorDescendantProperties
+        <3>. QED
+            BY <2>2, <3>2
+    <2>4. n \in A.node
+        BY <1>1, <2>3
+    <2>5. A # EmptyGraph
+        <3>1. A.node # {}
+            BY <2>3, <1>1
+        <3>2. EmptyGraph.node = {}
+            BY DEF EmptyGraph
+        <3>. QED
+            BY <3>1, <3>2
+    <2>. QED
+        BY <1>6, <2>4, <2>5
+<1>. QED
+    BY <1>5, <1>6
+
+(******************************************************************************)
+(* Still admitted: OpenSubGraphEquals needs the equality of the OpenPath-     *)
+(* start node set and the Ancestor node set in the Op-induced subgraph        *)
+(* (the path-based vs. closure-based views coincide).                         *)
+(******************************************************************************)
+THEOREM DDG_OpenSubGraphEqualsAncestorSubGraph ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O), NEW n, NEW Op(_),
+           IsFiniteSet(G.node)
+    PROVE  OpenSubGraph(G, n, Op) = AncestorSubGraph(G, n, Op)
+PROOF OMITTED
+
+THEOREM DDG_RetryUnionIsDag ==
+    ASSUME NEW G, IsDag(G), NEW t \in G.node, NEW u, u \notin G.node
+    PROVE  IsDag(GraphUnion(G, RetrySubGraph(G, t, u)))
+<1>1. IsDirectedGraph(G)
+    BY DEF IsDag
+<1> DEFINE preds == Predecessor(G, t)
+<1> DEFINE succs == Successor(G, t)
+<1> DEFINE R == RetrySubGraph(G, t, u)
+<1> DEFINE GU == GraphUnion(G, R)
+<1>2. /\ R.node = {u} \cup preds \cup succs
+      /\ R.edge = (preds \X {u}) \cup ({u} \X succs)
+      /\ preds \subseteq G.node /\ succs \subseteq G.node
+    BY DEF RetrySubGraph, Predecessor, Successor
+<1>3. /\ GU.node = G.node \cup R.node /\ GU.edge = G.edge \cup R.edge
+      /\ GU.node = G.node \cup {u}
+    BY <1>2 DEF GraphUnion
+<1>4. IsDirectedGraph(GU)
+    <2>1. G.edge \subseteq GU.node \X GU.node
+        BY <1>1, <1>3 DEF IsDirectedGraph
+    <2>2. R.edge \subseteq GU.node \X GU.node
+        BY <1>2, <1>3
+    <2>3. GU = [node |-> GU.node, edge |-> GU.edge]
+        BY DEF GraphUnion
+    <2>. QED
+        BY <2>1, <2>2, <2>3, <1>3 DEF IsDirectedGraph
+<1>5. ~HasDirectedCycle(GU)
+    <2> SUFFICES ASSUME HasDirectedCycle(GU) PROVE FALSE
+        OBVIOUS
+    <2>1. PICK c \in DirectedCycle(GU) : TRUE
+        BY DEF HasDirectedCycle
+    <2>2. /\ c \in Path(GU) /\ Len(c) > 1 /\ c[1] = c[Len(c)]
+          /\ c \in Seq(GU.node) /\ c # <<>> /\ Len(c) \in Nat
+          /\ \A i \in 1..(Len(c)-1) : <<c[i], c[i+1]>> \in GU.edge
+          /\ DOMAIN c = 1..Len(c)
+        BY <2>1, LenProperties DEF DirectedCycle, Path
+    <2> DEFINE c2 == [i \in 1..Len(c) |-> IF c[i] = u THEN t ELSE c[i]]
+    <2>3. \A i \in 1..Len(c) :
+              /\ c2[i] = (IF c[i] = u THEN t ELSE c[i])
+              /\ c2[i] \in G.node
+              /\ (c[i] # u => c2[i] = c[i])
+        <3> SUFFICES ASSUME NEW i \in 1..Len(c)
+                     PROVE  /\ c2[i] = (IF c[i] = u THEN t ELSE c[i])
+                            /\ c2[i] \in G.node
+                            /\ (c[i] # u => c2[i] = c[i])
+            OBVIOUS
+        <3>1. c[i] \in G.node \/ c[i] = u
+            BY <2>2, ElementOfSeq, <1>3
+        <3>. QED
+            BY <3>1
+    <2>4. /\ c2 \in Seq(G.node) /\ Len(c2) = Len(c) /\ DOMAIN c2 = 1..Len(c)
+          /\ c2 # <<>> /\ Len(c2) > 1
+        BY <2>3, <2>2, IsASeq, LenProperties, EmptySeq
+    <2>5. c2[1] = c2[Len(c2)]
+        <3>1. 1 \in 1..Len(c) /\ Len(c) \in 1..Len(c)
+            BY <2>2
+        <3>. QED
+            BY <3>1, <2>3, <2>2, <2>4
+    <2>6. \A i \in 1..(Len(c)-1) : <<c2[i], c2[i+1]>> \in G.edge
+        <3> SUFFICES ASSUME NEW i \in 1..(Len(c)-1)
+                     PROVE  <<c2[i], c2[i+1]>> \in G.edge
+            OBVIOUS
+        <3>i. i \in 1..Len(c) /\ i+1 \in 1..Len(c)
+            BY <2>2
+        <3>1. <<c[i], c[i+1]>> \in G.edge \/ <<c[i], c[i+1]>> \in R.edge
+            BY <2>2, <1>3
+        <3>2. CASE <<c[i], c[i+1]>> \in G.edge
+            <4>1. c[i] \in G.node /\ c[i+1] \in G.node /\ c[i] # u /\ c[i+1] # u
+                BY <3>2, <1>1 DEF IsDirectedGraph
+            <4>. QED
+                BY <4>1, <2>3, <3>i, <3>2
+        <3>3. CASE <<c[i], c[i+1]>> \in R.edge
+            <4>1. (c[i] \in preds /\ c[i+1] = u) \/ (c[i] = u /\ c[i+1] \in succs)
+                BY <3>3, <1>2
+            <4>2. CASE c[i] \in preds /\ c[i+1] = u
+                <5>1. c[i] \in G.node /\ c[i] # u
+                    BY <4>2, <1>2
+                <5>. QED
+                    BY <5>1, <4>2, <2>3, <3>i DEF Predecessor
+            <4>3. CASE c[i] = u /\ c[i+1] \in succs
+                <5>1. c[i+1] \in G.node /\ c[i+1] # u
+                    BY <4>3, <1>2
+                <5>. QED
+                    BY <5>1, <4>3, <2>3, <3>i DEF Successor
+            <4>. QED
+                BY <4>1, <4>2, <4>3
+        <3>. QED
+            BY <3>1, <3>2, <3>3
+    <2>7. c2 \in Path(G) /\ c2 \in DirectedCycle(G)
+        BY <2>4, <2>5, <2>6 DEF Path, DirectedCycle
+    <2>. QED
+        BY <2>7 DEF IsDag, HasDirectedCycle
+<1>. QED
+    BY <1>4, <1>5 DEF IsDag
+
+THEOREM DDG_RetrySubGraphProperties ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+           NEW Op(_), NEW t \in T \cap G.node, NEW u, u \notin (T \cup O)
+    PROVE  LET R == RetrySubGraph(G, t, u) IN
+           /\ IsDDGraph(R, {u}, O)
+           /\ IsWeaklyConnected(R)
+           /\ IsDDGraph(GraphUnion(G, R), T \cup {u}, O)
+<1> DEFINE preds == Predecessor(G, t)
+<1> DEFINE succs == Successor(G, t)
+<1> DEFINE R == RetrySubGraph(G, t, u)
+<1> DEFINE GU == GraphUnion(G, R)
+(* Setup: facts about G, t and R *)
+<1>1. /\ IsDirectedGraph(G) /\ IsDag(G)
+      /\ IsBipartiteWithPartitions(G, T, O)
+      /\ T \cap O = {} /\ G.node \subseteq T \cup O
+      /\ u \notin O /\ u \notin T /\ u \notin G.node
+    BY DEF IsDDGraph, IsDag, IsBipartiteWithPartitions
+<1>2. /\ R.node = {u} \cup preds \cup succs
+      /\ R.edge = (preds \X {u}) \cup ({u} \X succs)
+      /\ preds \subseteq G.node /\ succs \subseteq G.node
+    BY DEF RetrySubGraph, Predecessor, Successor
+(* The neighborhood of a task is in O, and non-empty *)
+<1>3. preds \subseteq O /\ succs \subseteq O
+    BY <1>1, DDG_BipartiteNeighborhood
+<1>4. preds /= {} /\ succs /= {}
+    BY <1>1, DDG_DDGraphProperties
+<1>5. R.node \subseteq {u} \cup O
+    BY <1>2, <1>3
+<1>6. IsDirectedGraph(R)
+    <2>1. R.edge \subseteq R.node \X R.node
+        BY <1>2
+    <2>2. R = [node |-> R.node, edge |-> R.edge]
+        BY DEF RetrySubGraph
+    <2>. QED
+        BY <2>1, <2>2 DEF IsDirectedGraph
+(* GraphUnion(G, R) is a DAG, hence so is R *)
+<1>7. IsDag(GraphUnion(G, R))
+    BY <1>1, DDG_RetryUnionIsDag
+<1>8. /\ R \in DirectedSubgraph(GraphUnion(G, R))
+      /\ IsDag(R)
+    <2>1. GU.node = G.node \cup R.node /\ GU.edge = G.edge \cup R.edge
+        BY DEF GraphUnion
+    <2>2. R.node \in SUBSET GU.node /\ R.edge \in SUBSET (GU.node \X GU.node)
+        BY <2>1, <1>2
+    <2>3. R = [node |-> R.node, edge |-> R.edge] /\ R.edge \subseteq GU.edge
+        BY <2>1 DEF RetrySubGraph
+    <2>4. R \in DirectedSubgraph(GraphUnion(G, R))
+        BY <2>2, <2>3, <1>6 DEF DirectedSubgraph
+    <2>. QED
+        BY <2>4, <1>7, DG_DirectedSubgraphProperties
+(* Conjunct 1: IsDDGraph(R, {u}, O) *)
+<1>9. IsDDGraph(R, {u}, O)
+    <2>1. IsBipartiteWithPartitions(R, {u}, O)
+        <3>1. {u} \cap O = {} /\ R.node \subseteq {u} \cup O
+            BY <1>1, <1>5
+        <3>2. \A e \in R.edge :
+                  (e[1] \in {u} /\ e[2] \in O) \/ (e[2] \in {u} /\ e[1] \in O)
+            BY <1>2, <1>3
+        <3>. QED
+            BY <3>1, <3>2 DEF IsBipartiteWithPartitions
+    <2>2. Source(R) \subseteq O
+        <3> SUFFICES ASSUME NEW x \in Source(R) PROVE x \in O
+            OBVIOUS
+        <3>1. x \in R.node /\ Predecessor(R, x) = {}
+            BY DEF Source
+        <3>2. x # u
+            <4>1. PICK p \in preds : TRUE
+                BY <1>4
+            <4>. QED
+                BY <4>1, <1>2, <3>1 DEF Predecessor
+        <3>3. x \notin succs
+            <4> SUFFICES ASSUME x \in succs PROVE FALSE
+                OBVIOUS
+            <4>1. <<u, x>> \in R.edge /\ u \in R.node
+                BY <1>2
+            <4>. QED
+                BY <4>1, <3>1 DEF Predecessor
+        <3>. QED
+            BY <3>1, <3>2, <3>3, <1>2, <1>3
+    <2>3. Sink(R) \subseteq O
+        <3> SUFFICES ASSUME NEW x \in Sink(R) PROVE x \in O
+            OBVIOUS
+        <3>1. x \in R.node /\ Successor(R, x) = {}
+            BY DEF Sink
+        <3>2. x # u
+            <4>1. PICK s \in succs : TRUE
+                BY <1>4
+            <4>. QED
+                BY <4>1, <1>2, <3>1 DEF Successor
+        <3>3. x \notin preds
+            <4> SUFFICES ASSUME x \in preds PROVE FALSE
+                OBVIOUS
+            <4>1. <<x, u>> \in R.edge /\ u \in R.node
+                BY <1>2
+            <4>. QED
+                BY <4>1, <3>1 DEF Successor
+        <3>. QED
+            BY <3>1, <3>2, <3>3, <1>2, <1>3
+    <2>. QED
+        BY <1>8, <2>1, <2>2, <2>3 DEF IsDDGraph
+(* Conjunct 2: IsWeaklyConnected(R) via hub at u *)
+<1>10. IsWeaklyConnected(R)
+    <2>1. u \in R.node
+        BY <1>2
+    <2>2. \A m \in R.node : AreConnectedIn(R, m, u) \/ AreConnectedIn(R, u, m)
+        <3> SUFFICES ASSUME NEW m \in R.node
+                     PROVE  AreConnectedIn(R, m, u) \/ AreConnectedIn(R, u, m)
+            OBVIOUS
+        <3>1. m = u \/ m \in preds \/ m \in succs
+            BY <1>2
+        <3>2. CASE m = u
+            BY <3>2, <2>1, DG_AreConnectedReflexive
+        <3>3. CASE m \in preds
+            BY <3>3, <1>2, <1>6, DG_EdgeConnects
+        <3>4. CASE m \in succs
+            BY <3>4, <1>2, <1>6, DG_EdgeConnects
+        <3>. QED
+            BY <3>1, <3>2, <3>3, <3>4
+    <2>. QED
+        BY <2>1, <2>2, <1>6, DG_WeaklyConnectedViaHub
+(* Conjunct 3: IsDDGraph(GU, T \cup {u}, O) *)
+<1>11. IsDDGraph(GU, T \cup {u}, O)
+    <2>1. GU.node = G.node \cup R.node /\ GU.edge = G.edge \cup R.edge
+        BY DEF GraphUnion
+    <2>2. GU.node \subseteq (T \cup {u}) \cup O
+        BY <2>1, <1>1, <1>5
+    <2>3. IsBipartiteWithPartitions(GU, T \cup {u}, O)
+        <3>1. (T \cup {u}) \cap O = {}
+            BY <1>1
+        <3>2. \A e \in GU.edge :
+                  (e[1] \in (T \cup {u}) /\ e[2] \in O) \/ (e[2] \in (T \cup {u}) /\ e[1] \in O)
+            <4> SUFFICES ASSUME NEW e \in GU.edge
+                         PROVE  (e[1] \in (T \cup {u}) /\ e[2] \in O)
+                                  \/ (e[2] \in (T \cup {u}) /\ e[1] \in O)
+                OBVIOUS
+            <4>1. e \in G.edge \/ e \in R.edge
+                BY <2>1
+            <4>2. CASE e \in G.edge
+                BY <4>2, <1>1 DEF IsBipartiteWithPartitions
+            <4>3. CASE e \in R.edge
+                <5>1. (e[1] \in preds /\ e[2] = u) \/ (e[1] = u /\ e[2] \in succs)
+                    BY <4>3, <1>2
+                <5>. QED
+                    BY <5>1, <1>3
+            <4>. QED
+                BY <4>1, <4>2, <4>3
+        <3>. QED
+            BY <3>1, <2>2, <3>2 DEF IsBipartiteWithPartitions
+    <2>4. \A x \in GU.node \cap (T \cup {u}) :
+              Predecessor(GU, x) /= {} /\ Successor(GU, x) /= {}
+        <3> SUFFICES ASSUME NEW x \in GU.node \cap (T \cup {u})
+                     PROVE  Predecessor(GU, x) /= {} /\ Successor(GU, x) /= {}
+            OBVIOUS
+        <3>1. CASE x = u
+            <4>1. PICK p \in preds, s \in succs : TRUE
+                BY <1>4
+            <4>2. <<p, u>> \in GU.edge /\ <<u, s>> \in GU.edge
+                BY <4>1, <1>2, <2>1
+            <4>3. p \in GU.node /\ s \in GU.node
+                BY <4>1, <1>2, <2>1
+            <4>. QED
+                BY <3>1, <4>2, <4>3 DEF Predecessor, Successor
+        <3>2. CASE x \in T
+            <4>1. x \in G.node \cap T
+                BY <3>2, <1>1, <1>2, <2>1
+            <4>2. PICK p \in Predecessor(G, x), s \in Successor(G, x) : TRUE
+                BY <4>1, <1>1, DDG_DDGraphProperties
+            <4>3. /\ <<p, x>> \in GU.edge /\ <<x, s>> \in GU.edge
+                  /\ p \in GU.node /\ s \in GU.node
+                BY <4>2, <2>1, <1>1 DEF Predecessor, Successor, IsDirectedGraph
+            <4>. QED
+                BY <4>3 DEF Predecessor, Successor
+        <3>. QED
+            BY <3>1, <3>2
+    <2>5. Source(GU) \subseteq O
+        <3> SUFFICES ASSUME NEW x \in Source(GU) PROVE x \in O
+            OBVIOUS
+        <3>1. x \in GU.node /\ Predecessor(GU, x) = {}
+            BY DEF Source
+        <3>2. x \notin (T \cup {u})
+            BY <3>1, <2>4
+        <3>. QED
+            BY <3>1, <3>2, <2>2
+    <2>6. Sink(GU) \subseteq O
+        <3> SUFFICES ASSUME NEW x \in Sink(GU) PROVE x \in O
+            OBVIOUS
+        <3>1. x \in GU.node /\ Successor(GU, x) = {}
+            BY DEF Sink
+        <3>2. x \notin (T \cup {u})
+            BY <3>1, <2>4
+        <3>. QED
+            BY <3>1, <3>2, <2>2
+    <2>. QED
+        BY <1>7, <2>3, <2>5, <2>6 DEF IsDDGraph
+<1>. QED
+    BY <1>9, <1>10, <1>11
+
+THEOREM DDG_AncestorSubGraphBasic ==
+    ASSUME NEW G, IsDirectedGraph(G), NEW n, NEW Op(_)
+    PROVE  LET A == AncestorSubGraph(G, n, Op) IN
+           /\ A \in DirectedSubgraph(G)
+           /\ A.node \subseteq {y \in G.node : Op(y)}
+<1> DEFINE InducedNodes == {y \in G.node : Op(y)}
+<1> DEFINE InducedGraph == [node |-> InducedNodes,
+                            edge |-> G.edge \cap (InducedNodes \X InducedNodes)]
+<1> DEFINE N == IF n \in InducedNodes THEN Ancestor(InducedGraph, n) ELSE {}
+<1> DEFINE A == AncestorSubGraph(G, n, Op)
+<1>1. /\ A = [node |-> N, edge |-> G.edge \cap (N \X N)]
+      /\ A.node = N /\ A.edge = G.edge \cap (N \X N)
+      /\ N \subseteq InducedNodes
+      /\ A.node \subseteq InducedNodes /\ A.node \subseteq G.node
+      /\ A.edge \subseteq G.edge
+    <2>1. A = [node |-> N, edge |-> G.edge \cap (N \X N)]
+        BY DEF AncestorSubGraph
+    <2>2. A.node = N /\ A.edge = G.edge \cap (N \X N)
+        <3> HIDE DEF A, N, InducedGraph, InducedNodes
+        <3> QED
+            BY <2>1
+    <2>3. N \subseteq InducedNodes
+        BY DEF Ancestor
+    <2>. QED
+        BY <2>1, <2>2, <2>3
+<1>2. A \in DirectedSubgraph(G)
+    <2>1. A.node \in SUBSET G.node /\ A.edge \in SUBSET (G.node \X G.node)
+        BY <1>1 DEF IsDirectedGraph
+    <2>2. IsDirectedGraph(A)
+        <3> HIDE DEF A, N, InducedGraph, InducedNodes
+        <3> QED
+            BY <1>1 DEF IsDirectedGraph
+    <2>. QED
+        BY <2>1, <2>2, <1>1 DEF DirectedSubgraph
+<1>. QED
+    BY <1>1, <1>2
+
+THEOREM DDG_DerivationProperties ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O), IsFiniteSet(G.node),
+           NEW n \in O, NEW Op(_), NEW D \in Derivation(G, n, Op, T)
+    PROVE  /\ IsDDGraph(D, T, O)
+           /\ IsWeaklyConnected(D)
+           /\ \A m \in D.node : Op(m)
+           /\ \A m \in D.node : AreConnectedIn(D, m, n)
+<1> DEFINE V == AncestorSubGraph(G, n, Op)
+(* Setup: V is a DirectedSubgraph of G with Op-satisfying nodes;
+   D is a DirectedSubgraph of V with the Derivation constraints. *)
+<1>1. /\ IsDirectedGraph(G) /\ T \cap O = {} /\ G.node \subseteq T \cup O
+      /\ V \in DirectedSubgraph(G) /\ V.node \subseteq {y \in G.node : Op(y)}
+      /\ V.node \subseteq G.node /\ V.edge \subseteq G.edge
+    <2>1. IsDirectedGraph(G) /\ T \cap O = {} /\ G.node \subseteq T \cup O
+        BY DEF IsDDGraph, IsDag, IsBipartiteWithPartitions
+    <2>2. V \in DirectedSubgraph(G) /\ V.node \subseteq {y \in G.node : Op(y)}
+        BY <2>1, DDG_AncestorSubGraphBasic
+    <2>. QED
+        BY <2>1, <2>2 DEF DirectedSubgraph
+<1>2. /\ D \in DirectedSubgraph(V)
+      /\ Sink(D) = {n}
+      /\ Source(D) \subseteq Source(G)
+      /\ \A tt \in D.node \cap T : Predecessor(G, tt) \subseteq D.node
+      /\ D.node \subseteq V.node /\ D.edge \subseteq V.edge /\ IsDirectedGraph(D)
+      /\ D.node \subseteq G.node /\ D.edge \subseteq G.edge
+      /\ IsFiniteSet(D.node)
+    <2>1. /\ D \in DirectedSubgraph(V)
+          /\ Sink(D) = {n}
+          /\ Source(D) \subseteq Source(G)
+          /\ \A tt \in D.node \cap T : Predecessor(G, tt) \subseteq D.node
+        BY DEF Derivation
+    <2>2. D.node \subseteq V.node /\ D.edge \subseteq V.edge /\ IsDirectedGraph(D)
+        BY <2>1 DEF DirectedSubgraph
+    <2>3. D.node \subseteq G.node /\ D.edge \subseteq G.edge
+        BY <2>2, <1>1
+    <2>. QED
+        BY <2>1, <2>2, <2>3, FS_Subset
+<1>3. D \in DirectedSubgraph(G)
+    <2>1. D.node \in SUBSET G.node /\ D.edge \in SUBSET (G.node \X G.node)
+        BY <1>2, <1>1 DEF IsDirectedGraph
+    <2>2. D = [node |-> D.node, edge |-> D.edge]
+        BY <1>2 DEF IsDirectedGraph
+    <2>. QED
+        BY <2>1, <2>2, <1>2 DEF DirectedSubgraph
+(* Conjunct 3: every node satisfies Op *)
+<1>4. \A m \in D.node : Op(m)
+    BY <1>2, <1>1
+(* IsDag(D) follows from IsDag(G) via subgraph closure *)
+<1>5. IsDag(D)
+    BY <1>3, DG_DirectedSubgraphProperties DEF IsDDGraph
+(* Conjunct 1: IsDDGraph(D, T, O) *)
+<1>6. IsDDGraph(D, T, O)
+    <2>1. IsBipartiteWithPartitions(G, T, O)
+        BY DEF IsDDGraph
+    <2>2. IsBipartiteWithPartitions(D, T, O)
+        BY <1>3, <2>1, DG_DirectedSubgraphProperties
+    <2>3. Source(D) \subseteq O
+        BY <1>2 DEF IsDDGraph
+    <2>4. Sink(D) \subseteq O
+        BY <1>2
+    <2>. QED
+        BY <1>5, <2>2, <2>3, <2>4 DEF IsDDGraph
+(* Conjunct 4: every node reaches n inside D *)
+<1>7. \A m \in D.node : AreConnectedIn(D, m, n)
+    <2> SUFFICES ASSUME NEW m \in D.node PROVE AreConnectedIn(D, m, n)
+        OBVIOUS
+    <2>1. PICK dd \in Sink(D) : AreConnectedIn(D, m, dd)
+        BY <1>5, <1>2, DG_DagReachesSink
+    <2>. QED
+        BY <2>1, <1>2
+(* Conjunct 2: weakly connected (vacuous when empty, hub at n otherwise) *)
+<1>8. IsWeaklyConnected(D)
+    <2>1. CASE D.node = {}
+        BY <2>1 DEF IsWeaklyConnected
+    <2>2. CASE D.node # {}
+        <3>1. n \in D.node
+            BY <1>2 DEF Sink
+        <3>. QED
+            BY <3>1, <1>2, <1>7, DG_WeaklyConnectedViaHub
+    <2>. QED
+        BY <2>1, <2>2
+<1>. QED
+    BY <1>6, <1>8, <1>4, <1>7
+
+THEOREM DDG_NoDerivationMeansBlockedAncestor ==
+    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+           NEW n \in G.node, NEW Op(_)
+    PROVE  Derivation(G, n, Op, T) = {} => \E m \in Ancestor(G, n) : ~Op(m)
+(* Contrapositive: if every ancestor of n is Op, the ancestor-induced        *)
+(* subgraph A is a derivation, contradicting Derivation = {}.                 *)
+<1> SUFFICES ASSUME Derivation(G, n, Op, T) = {},
+                    \A m \in Ancestor(G, n) : Op(m)
+             PROVE  FALSE
+    OBVIOUS
+<1> DEFINE Anc == Ancestor(G, n)
+<1> DEFINE A == [node |-> Anc, edge |-> G.edge \cap (Anc \X Anc)]
+<1> DEFINE InducedNodes == {y \in G.node : Op(y)}
+<1> DEFINE InducedGraph == [node |-> InducedNodes,
+                            edge |-> G.edge \cap (InducedNodes \X InducedNodes)]
+<1> DEFINE V == AncestorSubGraph(G, n, Op)
+(* Setup: G is a DAG, A is the Ancestor-induced subgraph of n in G *)
+<1>1. /\ IsDirectedGraph(G) /\ IsDag(G)
+      /\ Anc \subseteq G.node /\ n \in Anc /\ Op(n) /\ n \in InducedNodes
+      /\ A.node = Anc /\ A.edge = G.edge \cap (Anc \X Anc) /\ A.edge \subseteq G.edge
+      /\ IsDirectedGraph(A)
+      /\ IsDirectedGraph(InducedGraph)
+    <2>1. IsDirectedGraph(G) /\ IsDag(G)
+        BY DEF IsDDGraph, IsDag
+    <2>2. Anc \subseteq G.node /\ n \in Anc
+        BY <2>1, DG_AncestorDescendantProperties
+    <2>3. IsDirectedGraph(A)
+        BY DEF IsDirectedGraph
+    <2>. QED
+        BY <2>1, <2>2, <2>3 DEF IsDirectedGraph
+(* Predecessor closure: any predecessor of an ancestor is an ancestor *)
+<1>2. \A x \in Anc : \A z \in Predecessor(G, x) : z \in Anc
+    <2> SUFFICES ASSUME NEW x \in Anc, NEW z \in Predecessor(G, x) PROVE z \in Anc
+        OBVIOUS
+    <2>1. <<z, x>> \in G.edge
+        BY DEF Predecessor
+    <2>. QED
+        BY <2>1, <1>1, DG_AncestorClosedUnderPredecessor DEF Ancestor
+(* Anc lies inside the Op-induced ancestor set: use DDG_PathLiftToOpInduced *)
+<1>3. Anc \subseteq Ancestor(InducedGraph, n)
+    <2> SUFFICES ASSUME NEW x \in Anc PROVE x \in Ancestor(InducedGraph, n)
+        OBVIOUS
+    <2>1. PICK p \in SimplePath(G) : p[1] = x /\ p[Len(p)] = n
+        BY DEF Ancestor, AreConnectedIn
+    <2>2. \A i \in 1..Len(p) : Op(p[i])
+        <3> SUFFICES ASSUME NEW i \in 1..Len(p) PROVE Op(p[i])
+            OBVIOUS
+        <3>1. p[i] \in Ancestor(G, p[Len(p)])
+            BY <2>1, <1>1, DG_AncestorOnPath
+        <3>. QED
+            BY <3>1, <2>1, <1>1
+    <2>3. p \in SimplePath(InducedGraph) /\ p[1] = x /\ p[Len(p)] = n
+        BY <2>1, <2>2, <1>1, DDG_PathLiftToOpInduced
+    <2>. QED
+        BY <2>3 DEF AreConnectedIn, Ancestor
+(* A is a directed subgraph of V *)
+<1>4. A \in DirectedSubgraph(V)
+    <2>1. V = [node |-> Ancestor(InducedGraph, n),
+               edge |-> G.edge \cap (Ancestor(InducedGraph, n) \X Ancestor(InducedGraph, n))]
+        BY <1>1 DEF AncestorSubGraph
+    <2>2. V.node = Ancestor(InducedGraph, n)
+      /\ V.edge = G.edge \cap (V.node \X V.node)
+        <3> HIDE DEF V, InducedGraph, InducedNodes
+        <3> QED
+            BY <2>1
+    <2>3. A.node \subseteq V.node /\ A.edge \subseteq V.edge
+        <3>1. A.node \subseteq V.node
+            BY <1>1, <1>3, <2>2
+        <3>. QED
+            BY <3>1, <1>1, <2>2
+    <2>4. A.node \in SUBSET V.node /\ A.edge \in SUBSET (V.node \X V.node)
+        BY <2>3
+    <2>5. A = [node |-> A.node, edge |-> A.edge]
+        BY <1>1 DEF IsDirectedGraph
+    <2>. QED
+        BY <2>3, <2>4, <2>5, <1>1 DEF DirectedSubgraph
+(* Sink(A) = {n} *)
+<1>5. Sink(A) = {n}
+    <2>1. n \in Sink(A)
+        <3>1. n \in A.node
+            BY <1>1
+        <3>2. Successor(A, n) = {}
+            <4> SUFFICES ASSUME NEW y \in Successor(A, n) PROVE FALSE
+                OBVIOUS
+            <4>1. <<n, y>> \in A.edge /\ y \in A.node
+                BY DEF Successor
+            <4>2. <<n, y>> \in G.edge /\ y \in Anc
+                BY <4>1, <1>1
+            <4>3. AreConnectedIn(G, y, n)
+                BY <4>2 DEF Ancestor
+            <4>. QED
+                BY <4>3, <4>2, <1>1, DG_DagNoBackEdge
+        <3>. QED
+            BY <3>1, <3>2 DEF Sink
+    <2>2. Sink(A) \subseteq {n}
+        <3> SUFFICES ASSUME NEW x \in Sink(A), x # n PROVE FALSE
+            OBVIOUS
+        <3>1. x \in A.node /\ Successor(A, x) = {} /\ x \in Anc
+            BY <1>1 DEF Sink
+        <3>2. PICK p \in SimplePath(G) : p[1] = x /\ p[Len(p)] = n
+            BY <3>1 DEF Ancestor, AreConnectedIn
+        <3>3. /\ p \in Seq(G.node) /\ Len(p) \in Nat /\ Len(p) >= 1
+              /\ DOMAIN p = 1..Len(p)
+              /\ \A i \in 1..(Len(p) - 1) : <<p[i], p[i+1]>> \in G.edge
+            BY <3>2, DG_SimplePathIsSeq
+        <3>4. Len(p) >= 2
+            <4>1. SUFFICES Len(p) # 1 BY <3>3
+            <4>. QED
+                BY <3>2, <3>3
+        <3>5. 2 \in 1..Len(p) /\ 1 \in 1..(Len(p) - 1)
+            BY <3>3, <3>4
+        <3>6. p[2] \in Anc /\ <<x, p[2]>> \in G.edge
+            <4>1. p[2] \in Ancestor(G, p[Len(p)])
+                BY <3>5, <3>2, <1>1, DG_AncestorOnPath
+            <4>. QED
+                BY <4>1, <3>2, <3>5, <3>3
+        <3>7. p[2] \in A.node /\ <<x, p[2]>> \in A.edge
+            BY <3>6, <3>1, <1>1
+        <3>. QED
+            BY <3>7, <3>1 DEF Successor
+    <2>. QED
+        BY <2>1, <2>2
+(* Source(A) \subseteq Source(G) *)
+<1>6. Source(A) \subseteq Source(G)
+    <2> SUFFICES ASSUME NEW x \in Source(A) PROVE x \in Source(G)
+        OBVIOUS
+    <2>1. x \in A.node /\ Predecessor(A, x) = {} /\ x \in Anc /\ x \in G.node
+        BY <1>1 DEF Source
+    <2>2. Predecessor(G, x) = {}
+        <3> SUFFICES ASSUME NEW z \in Predecessor(G, x) PROVE FALSE
+            OBVIOUS
+        <3>1. z \in Anc /\ <<z, x>> \in G.edge
+            BY <2>1, <1>2 DEF Predecessor
+        <3>2. <<z, x>> \in A.edge /\ z \in A.node
+            BY <3>1, <2>1, <1>1
+        <3>. QED
+            BY <3>2, <2>1 DEF Predecessor
+    <2>. QED
+        BY <2>1, <2>2 DEF Source
+(* Every task in A has all its predecessors in A *)
+<1>7. \A tt \in A.node \cap T : Predecessor(G, tt) \subseteq A.node
+    <2> SUFFICES ASSUME NEW tt \in A.node \cap T, NEW z \in Predecessor(G, tt)
+                 PROVE  z \in A.node
+        OBVIOUS
+    <2>. QED
+        BY <1>1, <1>2
+(* A is a derivation, contradicting Derivation = {} *)
+<1>8. A \in Derivation(G, n, Op, T)
+    BY <1>4, <1>5, <1>6, <1>7 DEF Derivation
+<1>. QED
+    BY <1>8
+
+================================================================================

--- a/specs/DDGraphs.java
+++ b/specs/DDGraphs.java
@@ -1,0 +1,263 @@
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import tlc2.value.impl.RecordValue;
+import tlc2.value.impl.SetEnumValue;
+import tlc2.value.impl.TupleValue;
+import tlc2.value.impl.Value;
+import util.UniqueString;
+
+public final class DDGraphs {
+
+    private static final Logger LOGGER = Logger.getLogger(DDGraphs.class.getName());
+
+    private static final UniqueString NODE_KEY = UniqueString.of("node");
+    private static final UniqueString EDGE_KEY = UniqueString.of("edge");
+    // TLC's UniqueString.compareTo orders by interning tag (allocation order),
+    // not lexically. We pre-sort by that comparator so the resulting record
+    // is "already normalized" and matches the canonical layout TLC's parser
+    // produces for [node |-> ..., edge |-> ...] literals.
+    private static final UniqueString[] RECORD_NAMES;
+    private static final boolean NODE_FIRST;
+    static {
+        if (NODE_KEY.compareTo(EDGE_KEY) <= 0) {
+            RECORD_NAMES = new UniqueString[]{NODE_KEY, EDGE_KEY};
+            NODE_FIRST = true;
+        } else {
+            RECORD_NAMES = new UniqueString[]{EDGE_KEY, NODE_KEY};
+            NODE_FIRST = false;
+        }
+    }
+
+    private static RecordValue makeRecord(Value nodeSet, Value edgeSet) {
+        Value[] values = NODE_FIRST
+                ? new Value[]{nodeSet, edgeSet}
+                : new Value[]{edgeSet, nodeSet};
+        return new RecordValue(RECORD_NAMES, values, true);
+    }
+
+    private DDGraphs() {
+        // no-instantiation
+    }
+
+    /**
+     * Java overload of the TLA+ operator {@code DDGraphOf(T, O)} defined in
+     * {@code DDGraphs.tla}. Returns the set of all Data-Dependency graphs over
+     * task ids {@code T} and object ids {@code O}.
+     * <p>
+     * A graph {@code g = [node, edge]} belongs to the result iff there exists a
+     * pair {@code (t, o)} with {@code t} a subset of {@code T} and {@code o} a
+     * subset of {@code O} such that:
+     * <ul>
+     *   <li>{@code g.node} equals {@code t} union {@code o};</li>
+     *   <li>{@code g.edge} is a subset of {@code (t x o) cup (o x t)};</li>
+     *   <li>{@code g} is a DAG;</li>
+     *   <li>every root of {@code g} is in {@code o} (tasks are never roots);</li>
+     *   <li>every leaf of {@code g} is in {@code o} (tasks are never leaves).</li>
+     * </ul>
+     * Objects may be isolated and may have any number of predecessors.
+     * <p>
+     * Implementation: bitmask enumeration. For each {@code (t, o)} pair, each
+     * task independently picks a pair {@code (P, S)} of disjoint non-empty
+     * subsets of {@code o}; the induced task-to-task relation
+     * {@code u -> v iff S(u) intersect P(v) is non-empty} is then checked for
+     * acyclicity via DFS over bitmask adjacency.
+     */
+    public static Value DDGraphOf(final Value t, final Value o) throws Exception {
+        Value tEnum = t.toSetEnum();
+        Value oEnum = o.toSetEnum();
+        if (!(tEnum instanceof SetEnumValue)) {
+            throw new Exception("Task ids must be a set; got " + t.getClass().getName());
+        }
+        if (!(oEnum instanceof SetEnumValue)) {
+            throw new Exception("Object ids must be a set; got " + o.getClass().getName());
+        }
+        Value[] allTasks = ((SetEnumValue) tEnum).elems.toArray();
+        Value[] allObjects = ((SetEnumValue) oEnum).elems.toArray();
+
+        if (allTasks.length > 30 || allObjects.length > 30) {
+            throw new Exception("DDGraphOf: bitmask enumeration is limited to 30 task/object ids");
+        }
+
+        LOGGER.log(Level.FINE, "DDGraphOf: |T|={0}, |O|={1}",
+                new Object[]{allTasks.length, allObjects.length});
+
+        List<Value> results = new ArrayList<>();
+
+        for (int tMask = 0; tMask < (1 << allTasks.length); tMask++) {
+            Value[] tasks = pick(allTasks, tMask);
+            for (int oMask = 0; oMask < (1 << allObjects.length); oMask++) {
+                Value[] objects = pick(allObjects, oMask);
+                enumerate(tasks, objects, results);
+            }
+        }
+
+        LOGGER.log(Level.FINE, "DDGraphOf: produced {0} graphs", results.size());
+        return new SetEnumValue(results.toArray(new Value[0]), false);
+    }
+
+    /**
+     * Enumerate every DDGraph over the given task / object subsets and append
+     * the resulting {@link RecordValue}s to {@code out}.
+     */
+    private static void enumerate(Value[] tasks, Value[] objects, List<Value> out) {
+        if (tasks.length == 0) {
+            out.add(emptyEdgeRecord(objects));
+            return;
+        }
+        if (objects.length == 0) {
+            return; // tasks would be isolated roots/leaves, violating the spec
+        }
+
+        long[][] options = new long[tasks.length][];
+        for (int i = 0; i < tasks.length; i++) {
+            options[i] = predSuccOptions(objects, tasks[i]);
+            if (options[i].length == 0) {
+                return; // some task has no valid (P, S) — no graph in this (t, o) cell
+            }
+        }
+
+        int[] indices = new int[tasks.length];
+        int[][] ps = new int[tasks.length][2];
+        while (true) {
+            for (int i = 0; i < tasks.length; i++) {
+                long packed = options[i][indices[i]];
+                ps[i][0] = (int) (packed >>> 32);
+                ps[i][1] = (int) packed;
+            }
+            if (taskGraphIsAcyclic(ps)) {
+                out.add(record(tasks, objects, ps));
+            }
+            if (!advance(indices, options)) {
+                break;
+            }
+        }
+    }
+
+    // (P, S) options for a task, packed as ((long) P << 32) | S. Bit k of P
+    // (resp. S) means objects[k] is a predecessor (resp. successor) of the
+    // task. P and S are disjoint, both non-empty, and never include the task
+    // itself (the last clause only matters when T and O overlap).
+    private static long[] predSuccOptions(Value[] objects, Value task) {
+        int n = objects.length;
+        int forbid = 0;
+        for (int i = 0; i < n; i++) {
+            if (objects[i].equals(task)) {
+                forbid |= 1 << i;
+            }
+        }
+        int allowed = ((1 << n) - 1) & ~forbid;
+        List<Long> opts = new ArrayList<>();
+        // Iterate over every non-empty P subset of `allowed`.
+        for (int p = allowed; p > 0; p = (p - 1) & allowed) {
+            int rest = allowed & ~p;
+            // Iterate over every non-empty S subset of `rest`.
+            for (int s = rest; s > 0; s = (s - 1) & rest) {
+                opts.add(((long) p << 32) | (s & 0xFFFFFFFFL));
+            }
+        }
+        long[] out = new long[opts.size()];
+        for (int i = 0; i < opts.size(); i++) {
+            out[i] = opts.get(i);
+        }
+        return out;
+    }
+
+    /**
+     * The bipartite graph is a DAG iff the induced task-to-task relation
+     * {@code u_i -> u_j iff S(u_i) \cap P(u_j) != \emptyset} is acyclic.
+     */
+    private static boolean taskGraphIsAcyclic(int[][] ps) {
+        int n = ps.length;
+        int[] adj = new int[n];
+        for (int i = 0; i < n; i++) {
+            int si = ps[i][1];
+            for (int j = 0; j < n; j++) {
+                if (i == j) continue;
+                if ((si & ps[j][0]) != 0) {
+                    adj[i] |= 1 << j;
+                }
+            }
+        }
+        byte[] color = new byte[n]; // 0 = white, 1 = gray, 2 = black
+        for (int i = 0; i < n; i++) {
+            if (color[i] == 0 && hasCycle(i, adj, color)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean hasCycle(int v, int[] adj, byte[] color) {
+        color[v] = 1;
+        int bits = adj[v];
+        while (bits != 0) {
+            int w = Integer.numberOfTrailingZeros(bits);
+            if (color[w] == 1) return true;
+            if (color[w] == 0 && hasCycle(w, adj, color)) return true;
+            bits &= bits - 1;
+        }
+        color[v] = 2;
+        return false;
+    }
+
+    private static boolean advance(int[] indices, long[][] options) {
+        for (int k = indices.length - 1; k >= 0; k--) {
+            if (++indices[k] < options[k].length) {
+                return true;
+            }
+            indices[k] = 0;
+        }
+        return false;
+    }
+
+    private static Value[] pick(Value[] all, int mask) {
+        int n = Integer.bitCount(mask);
+        Value[] out = new Value[n];
+        int j = 0;
+        int bits = mask;
+        while (bits != 0) {
+            int i = Integer.numberOfTrailingZeros(bits);
+            out[j++] = all[i];
+            bits &= bits - 1;
+        }
+        return out;
+    }
+
+    /** Build the record for an edge-less object-only graph. */
+    private static RecordValue emptyEdgeRecord(Value[] objects) {
+        Value nodeSet = new SetEnumValue(objects.clone(), false);
+        Value edgeSet = new SetEnumValue(new Value[0], false);
+        return makeRecord(nodeSet, edgeSet);
+    }
+
+    /** Build the record for a (t, o) graph given the per-task (P, S) selection. */
+    private static RecordValue record(Value[] tasks, Value[] objects, int[][] ps) {
+        Set<Value> nodes = new LinkedHashSet<>(Arrays.asList(tasks));
+        nodes.addAll(Arrays.asList(objects));
+        Value nodeSet = new SetEnumValue(nodes.toArray(new Value[0]), false);
+
+        List<TupleValue> edges = new ArrayList<>();
+        for (int i = 0; i < tasks.length; i++) {
+            int p = ps[i][0];
+            int s = ps[i][1];
+            while (p != 0) {
+                int k = Integer.numberOfTrailingZeros(p);
+                edges.add(new TupleValue(objects[k], tasks[i]));
+                p &= p - 1;
+            }
+            while (s != 0) {
+                int k = Integer.numberOfTrailingZeros(s);
+                edges.add(new TupleValue(tasks[i], objects[k]));
+                s &= s - 1;
+            }
+        }
+        Value edgeSet = new SetEnumValue(edges.toArray(new Value[0]), false);
+        return makeRecord(nodeSet, edgeSet);
+    }
+}

--- a/specs/DDGraphs.tla
+++ b/specs/DDGraphs.tla
@@ -1,0 +1,136 @@
+-------------------------------- MODULE DDGraphs -------------------------------
+(******************************************************************************)
+(* Data-Dependency (DD) graphs and their upstream-derivation operators.       *)
+(*                                                                            *)
+(* A DD graph is a directed acyclic graph that is bipartite over two          *)
+(* disjoint node kinds:                                                       *)
+(*   - tasks: computations producing objects;                                 *)
+(*   - objects: data items consumed by tasks.                                 *)
+(* Every edge links a task to an object or an object to a task; sources and   *)
+(* sinks are always objects, so every task consumes at least one object and   *)
+(* produces at least one object.                                              *)
+(*                                                                            *)
+(* Several operators take a higher-order argument Op(_) that abstracts an     *)
+(* arbitrary per-node predicate. Callers typically instantiate it with their  *)
+(* own notion of "openness" (e.g. not yet finalized) or "validity" (e.g.      *)
+(* still able to contribute to a result). All operators using Op are          *)
+(* parametric in that predicate; nothing in this module fixes its meaning.    *)
+(******************************************************************************)
+
+EXTENDS DiGraphs
+
+(******************************************************************************)
+(* TRUE iff G is a DD graph over task ids T and object ids O: a DAG that is   *)
+(* bipartite over (T, O) and whose sources and sinks are all objects.         *)
+(******************************************************************************)
+IsDDGraph(G, T, O) ==
+    /\ IsDag(G)
+    /\ IsBipartiteWithPartitions(G, T, O)
+    /\ Source(G) \subseteq O
+    /\ Sink(G) \subseteq O
+
+(******************************************************************************)
+(* The set of all DD graphs over task ids T and object ids O. The set         *)
+(* includes the empty graph and every graph whose nodes are a subset of       *)
+(* T \union O satisfying the DD-graph constraints.                            *)
+(*                                                                            *)
+(* The union is indexed by a single pair `to \in (SUBSET T) \X (SUBSET O)`    *)
+(* rather than the more natural two-binder comprehension                      *)
+(*   { ... : t \in SUBSET T, o \in SUBSET O }                                 *)
+(* (with `to[1]` standing for the task subset t and `to[2]` for the object    *)
+(* subset o). The two forms denote the same set, but TLAPS cannot unfold a    *)
+(* `UNION` over a multi-binder set comprehension -- so a member of the        *)
+(* two-binder form cannot be decomposed back into its (t, o) witness in a     *)
+(* proof. The single-binder Cartesian-product form has no such limitation,    *)
+(* which is what lets DDG_DDGraphOfMember be discharged.                      *)
+(******************************************************************************)
+DDGraphOf(T, O) ==
+    UNION {
+        { g \in [node: {to[1] \union to[2]}, edge: SUBSET ((to[1] \X to[2]) \union (to[2] \X to[1]))] :
+            /\ IsDag(g)
+            /\ Source(g) \subseteq to[2]
+            /\ Sink(g) \subseteq to[2]
+        } : to \in (SUBSET T) \X (SUBSET O)
+    }
+
+(******************************************************************************)
+(* The set of open paths ending at node n in G under predicate Op: simple     *)
+(* paths whose every node satisfies Op and whose last node is n. The set is   *)
+(* empty when n itself does not satisfy Op.                                   *)
+(******************************************************************************)
+OpenPath(G, n, Op(_)) ==
+    {p \in SimplePath(G) :
+        /\ p[Len(p)] = n
+        /\ \A i \in 1..Len(p) : Op(p[i])}
+
+(******************************************************************************)
+(* The open upstream subgraph of n in G under Op: the subgraph induced by     *)
+(* every node that lies on some open path ending at n. Empty when n itself    *)
+(* does not satisfy Op.                                                       *)
+(******************************************************************************)
+OpenSubGraph(G, n, Op(_)) ==
+    LET N == {p[1] : p \in OpenPath(G, n, Op)} IN
+    [node |-> N, edge |-> G.edge \cap (N \X N)]
+
+(******************************************************************************)
+(* The Op-induced ancestor subgraph of n in G: the subgraph of G induced by   *)
+(* the ancestors of n in the subgraph of G that retains only nodes            *)
+(* satisfying Op. Empty when n itself does not satisfy Op.                    *)
+(*                                                                            *)
+(* Equivalently: let R be the precedence relation of G restricted to nodes    *)
+(* satisfying Op. A node m belongs to the subgraph iff n satisfies Op and     *)
+(* either m = n or m reaches n through the transitive closure of R --         *)
+(* together those two cases form the reflexive-transitive closure of R        *)
+(* ending at n.                                                               *)
+(******************************************************************************)
+AncestorSubGraph(G, n, Op(_)) ==
+    LET InducedNodes == {m \in G.node : Op(m)}
+        InducedGraph == [node |-> InducedNodes,
+                         edge |-> G.edge \cap (InducedNodes \X InducedNodes)]
+        N == IF n \in InducedNodes
+             THEN Ancestor(InducedGraph, n)
+             ELSE {}
+    IN [node |-> N, edge |-> G.edge \cap (N \X N)]
+
+(******************************************************************************)
+(* The retry attachment of node t in G with fresh node u: the smallest        *)
+(* graph H such that GraphUnion(G, H) extends G with u placed in parallel to  *)
+(* t -- u has the same predecessors and the same successors as t in G, and    *)
+(* no edge links t to u. Intended use is RegisterGraph-style attachment of a  *)
+(* retry attempt whose data-dependency footprint mirrors that of a previous   *)
+(* attempt t.                                                                 *)
+(*                                                                            *)
+(* The node set contains u together with t's neighbors (so the result is a    *)
+(* well-formed graph in isolation), and is minimal: t itself is not included  *)
+(* since the caller already has it in G.                                      *)
+(******************************************************************************)
+RetrySubGraph(G, t, u) ==
+    LET preds == Predecessor(G, t)
+        succs == Successor(G, t)
+    IN  [node |-> {u} \union preds \union succs,
+         edge |-> (preds \X {u}) \union ({u} \X succs)]
+
+(******************************************************************************)
+(* The set of derivations of n in G under Op, with task partition T: every    *)
+(* subgraph of the ancestor subgraph of n that witnesses how n can be         *)
+(* produced from the sources of G.                                            *)
+(*                                                                            *)
+(* A derivation D satisfies:                                                  *)
+(*   - D is a directed subgraph of AncestorSubGraph(G, n, Op);                *)
+(*   - the only sink of D is n (D is unilaterally connected toward n);        *)
+(*   - the sources of D are a subset of the sources of G;                     *)
+(*   - every task in D has all its input objects in D (AND-semantics on       *)
+(*     task inputs).                                                          *)
+(*                                                                            *)
+(* The OR-semantics for objects (one parent task is enough to produce them)   *)
+(* is implied: a non-source object in D must have a predecessor in D, and     *)
+(* by bipartiteness of G that predecessor is a task.                          *)
+(******************************************************************************)
+Derivation(G, n, Op(_), T) ==
+    LET V == AncestorSubGraph(G, n, Op) IN
+    {D \in DirectedSubgraph(V) :
+        /\ Sink(D) = {n}
+        /\ Source(D) \subseteq Source(G)
+        /\ \A t \in D.node \cap T : Predecessor(G, t) \subseteq D.node}
+
+================================================================================

--- a/specs/DDGraphsTests.cfg
+++ b/specs/DDGraphsTests.cfg
@@ -1,0 +1,10 @@
+\* Empty model; TLC checks the ASSUME statements at startup.
+\* HasDirectedCycle is defined over the unbounded Seq(G.node) and is not
+\* TLC-evaluable; we override it with its MC equivalent so that IsDag (and
+\* therefore IsDDGraph) can be evaluated on concrete sample graphs.
+\* SimplePath is defined over the unbounded Seq(G.node); we likewise override
+\* it with MCSimplePath so that AreConnectedIn, Ancestor, OpenPath and the
+\* connectivity predicates remain enumerable.
+CONSTANTS
+    HasDirectedCycle <- MCHasDirectedCycle
+    SimplePath <- MCSimplePath

--- a/specs/DDGraphsTests.tla
+++ b/specs/DDGraphsTests.tla
@@ -1,0 +1,209 @@
+---------------------------- MODULE DDGraphsTests ------------------------------
+(******************************************************************************)
+(* Tests for the DDGraphs module.                                             *)
+(*                                                                            *)
+(* Each test is encoded as an `ASSUME` statement: TLC evaluates them at       *)
+(* startup and aborts as soon as one fails. Tests are grouped per operator    *)
+(* in the same order as the DDGraphs module.                                  *)
+(******************************************************************************)
+
+EXTENDS DDGraphs, TLCExt
+
+(******************************************************************************)
+(* Initialization                                                             *)
+(******************************************************************************)
+ASSUME LET T == INSTANCE TLC IN T!PrintT("DDGraphsTests")
+
+(******************************************************************************)
+(* Test predicates passed to the higher-order operators.                      *)
+(******************************************************************************)
+TestAll(x)  == TRUE
+TestNone(x) == FALSE
+TestNot2(x) == x /= 2
+TestNotT2(x) == x /= "t2"
+
+(******************************************************************************)
+(* IsDDGraph                                                                  *)
+(******************************************************************************)
+
+\* The empty graph is a DD graph over any partition.
+ASSUME AssertEq(IsDDGraph(EmptyGraph, {}, {}), TRUE)
+ASSUME AssertEq(IsDDGraph(EmptyGraph, {"t"}, {"o"}), TRUE)
+
+\* A canonical chain o1 -> t -> o2.
+ASSUME LET G == [node |-> {"t", "o1", "o2"},
+                 edge |-> {<<"o1", "t">>, <<"t", "o2">>}]
+       IN  AssertEq(IsDDGraph(G, {"t"}, {"o1", "o2"}), TRUE)
+
+\* Swapping the partition breaks bipartiteness (tasks on the object side).
+ASSUME LET G == [node |-> {"t", "o1", "o2"},
+                 edge |-> {<<"o1", "t">>, <<"t", "o2">>}]
+       IN  AssertEq(IsDDGraph(G, {"o1", "o2"}, {"t"}), FALSE)
+
+\* A task placed as a source is forbidden.
+ASSUME LET G == [node |-> {"t", "o"}, edge |-> {<<"t", "o">>}]
+       IN  AssertEq(IsDDGraph(G, {"t"}, {"o"}), FALSE)
+
+\* A task placed as a sink is forbidden.
+ASSUME LET G == [node |-> {"t", "o"}, edge |-> {<<"o", "t">>}]
+       IN  AssertEq(IsDDGraph(G, {"t"}, {"o"}), FALSE)
+
+\* A directed cycle is forbidden.
+ASSUME LET G == [node |-> {"t", "u", "o", "p"},
+                 edge |-> {<<"o", "t">>, <<"t", "p">>,
+                           <<"p", "u">>, <<"u", "o">>}]
+       IN  AssertEq(IsDDGraph(G, {"t", "u"}, {"o", "p"}), FALSE)
+
+(******************************************************************************)
+(* DDGraphOf                                                                  *)
+(******************************************************************************)
+ASSUME AssertEq(DDGraphOf({"t"}, {"o", "p"}), {
+        [node |-> {},              edge |-> {}],
+        [node |-> {"o"},           edge |-> {}],
+        [node |-> {"p"},           edge |-> {}],
+        [node |-> {"o", "p"},      edge |-> {}],
+        [node |-> {"t", "o", "p"}, edge |-> {<<"o", "t">>, <<"t", "p">>}],
+        [node |-> {"t", "o", "p"}, edge |-> {<<"p", "t">>, <<"t", "o">>}]
+    })
+
+ASSUME AssertEq(DDGraphOf({}, {"o"}), {
+        [node |-> {},    edge |-> {}],
+        [node |-> {"o"}, edge |-> {}]
+    })
+
+ASSUME AssertEq(Cardinality(DDGraphOf({"t", "u"}, {"o", "p", "q"})), 146)
+
+ASSUME AssertEq(Cardinality(DDGraphOf({"t", "u", "v"}, {"o", "p", "q"})), 962)
+
+\* Every member of DDGraphOf(T, O) satisfies IsDDGraph(G, T, O).
+ASSUME \A G \in DDGraphOf({"t"}, {"o", "p"}) : IsDDGraph(G, {"t"}, {"o", "p"})
+
+(******************************************************************************)
+(* OpenPath                                                                   *)
+(******************************************************************************)
+
+\* With an always-true predicate, OpenPath collects every simple path that
+\* ends at n.
+ASSUME LET G == [node |-> {1, 2, 3}, edge |-> {<<1, 2>>, <<2, 3>>}]
+       IN  AssertEq(OpenPath(G, 3, TestAll),
+                    {<<3>>, <<2, 3>>, <<1, 2, 3>>})
+
+\* A predicate that rejects every node yields no open path.
+ASSUME LET G == [node |-> {1, 2, 3}, edge |-> {<<1, 2>>, <<2, 3>>}]
+       IN  AssertEq(OpenPath(G, 3, TestNone), {})
+
+\* Excluding an intermediate node only leaves paths that avoid it; the
+\* singleton path <<3>> remains because Op(3) holds.
+ASSUME LET G == [node |-> {1, 2, 3}, edge |-> {<<1, 2>>, <<2, 3>>}]
+       IN  AssertEq(OpenPath(G, 3, TestNot2), {<<3>>})
+
+\* A target outside G.node has no open path.
+ASSUME LET G == [node |-> {1}, edge |-> {}]
+       IN  AssertEq(OpenPath(G, 2, TestAll), {})
+
+(******************************************************************************)
+(* OpenSubGraph                                                               *)
+(******************************************************************************)
+
+\* All-true predicate: every ancestor of 3 in G is in the open subgraph.
+ASSUME LET G == [node |-> {1, 2, 3}, edge |-> {<<1, 2>>, <<2, 3>>}]
+       IN  AssertEq(OpenSubGraph(G, 3, TestAll),
+                    [node |-> {1, 2, 3},
+                     edge |-> {<<1, 2>>, <<2, 3>>}])
+
+\* All-false predicate: empty subgraph.
+ASSUME LET G == [node |-> {1, 2, 3}, edge |-> {<<1, 2>>, <<2, 3>>}]
+       IN  AssertEq(OpenSubGraph(G, 3, TestNone),
+                    EmptyGraph)
+
+\* Excluding 2 cuts 1 off the open subgraph (no open path passes through 2).
+ASSUME LET G == [node |-> {1, 2, 3}, edge |-> {<<1, 2>>, <<2, 3>>}]
+       IN  AssertEq(OpenSubGraph(G, 3, TestNot2),
+                    [node |-> {3}, edge |-> {}])
+
+(******************************************************************************)
+(* AncestorSubGraph                                                           *)
+(******************************************************************************)
+
+\* All-true predicate: AncestorSubGraph yields the ancestor closure.
+ASSUME LET G == [node |-> {1, 2, 3}, edge |-> {<<1, 2>>, <<2, 3>>}]
+       IN  AssertEq(AncestorSubGraph(G, 3, TestAll), G)
+
+\* All-false predicate: empty.
+ASSUME LET G == [node |-> {1, 2, 3}, edge |-> {<<1, 2>>, <<2, 3>>}]
+       IN  AssertEq(AncestorSubGraph(G, 3, TestNone),
+                    EmptyGraph)
+
+\* Excluding 2 leaves only the target itself (1 can no longer reach 3).
+ASSUME LET G == [node |-> {1, 2, 3}, edge |-> {<<1, 2>>, <<2, 3>>}]
+       IN  AssertEq(AncestorSubGraph(G, 3, TestNot2),
+                    [node |-> {3}, edge |-> {}])
+
+\* OpenSubGraph and AncestorSubGraph coincide on a small diamond.
+ASSUME LET G == [node |-> {1, 2, 3, 4},
+                 edge |-> {<<1, 2>>, <<1, 3>>, <<2, 4>>, <<3, 4>>}]
+       IN  AssertEq(OpenSubGraph(G, 4, TestAll),
+                    AncestorSubGraph(G, 4, TestAll))
+
+\* When the target does not satisfy Op, both subgraphs are empty.
+ASSUME LET G == [node |-> {"t1", "t2", "o"},
+                 edge |-> {<<"t1", "o">>, <<"t2", "o">>}]
+       IN  /\ AssertEq(OpenSubGraph(G, "t2", TestNotT2),
+                       EmptyGraph)
+           /\ AssertEq(AncestorSubGraph(G, "t2", TestNotT2),
+                       EmptyGraph)
+
+(******************************************************************************)
+(* RetrySubGraph                                                              *)
+(******************************************************************************)
+
+\* The retry of t in a single-task chain creates u with the same wiring.
+ASSUME LET G == [node |-> {"t", "o1", "o2"},
+                 edge |-> {<<"o1", "t">>, <<"t", "o2">>}]
+       IN  AssertEq(RetrySubGraph(G, "t", "u"),
+                    [node |-> {"u", "o1", "o2"},
+                     edge |-> {<<"o1", "u">>, <<"u", "o2">>}])
+
+\* An isolated task retries into an isolated fresh node.
+ASSUME LET G == [node |-> {"t"}, edge |-> {}]
+       IN  AssertEq(RetrySubGraph(G, "t", "u"),
+                    [node |-> {"u"}, edge |-> {}])
+
+\* After attaching the retry, u mirrors t's neighborhood in the union.
+ASSUME LET G == [node |-> {"t", "o1", "o2", "o3"},
+                 edge |-> {<<"o1", "t">>, <<"o2", "t">>, <<"t", "o3">>}]
+           H == GraphUnion(G, RetrySubGraph(G, "t", "u"))
+       IN  /\ AssertEq(Predecessor(H, "u"), Predecessor(H, "t"))
+           /\ AssertEq(Successor(H, "u"),   Successor(H, "t"))
+
+(******************************************************************************)
+(* Derivation                                                                 *)
+(******************************************************************************)
+
+\* On the simple chain o1 -> t -> o2, the only derivation of o2 is the graph
+\* itself: dropping any node either removes the sink, exposes a non-source as
+\* a source, or strips a task of one of its required inputs.
+ASSUME LET G == [node |-> {"t", "o1", "o2"},
+                 edge |-> {<<"o1", "t">>, <<"t", "o2">>}]
+       IN  AssertEq(Derivation(G, "o2", TestAll, {"t"}), {G})
+
+\* Two tasks producing the same object: each task on its own yields a
+\* derivation; the union of both is also a derivation.
+ASSUME LET G == [node |-> {"t1", "t2", "o1", "o2", "o"},
+                 edge |-> {<<"o1", "t1">>, <<"t1", "o">>,
+                           <<"o2", "t2">>, <<"t2", "o">>}]
+           D1 == [node |-> {"o1", "t1", "o"},
+                  edge |-> {<<"o1", "t1">>, <<"t1", "o">>}]
+           D2 == [node |-> {"o2", "t2", "o"},
+                  edge |-> {<<"o2", "t2">>, <<"t2", "o">>}]
+       IN  Derivation(G, "o", TestAll, {"t1", "t2"}) = {D1, D2, G}
+
+\* Filtering out t2 with the predicate leaves only the derivation through t1.
+ASSUME LET G == [node |-> {"t1", "t2", "o1", "o2", "o"},
+                 edge |-> {<<"o1", "t1">>, <<"t1", "o">>,
+                           <<"o2", "t2">>, <<"t2", "o">>}]
+           D1 == [node |-> {"o1", "t1", "o"},
+                  edge |-> {<<"o1", "t1">>, <<"t1", "o">>}]
+       IN  Derivation(G, "o", TestNotT2, {"t1", "t2"}) = {D1}
+
+================================================================================


### PR DESCRIPTION
## Summary

  Adds a new `DDGraphs` module modelling data-dependency (DD) graphs — bipartite
  DAGs over disjoint task/object partitions whose sources and sinks are always
  objects — together with the upstream-derivation operators that downstream specs
  rely on.

  - `DDGraphs.tla`:
    - `IsDDGraph(G, T, O)` — DAG, bipartite over (T, O), sources/sinks ⊆ O.
    - `DDGraphOf(T, O)` — set of all DD graphs over (T, O), written as a
      single-binder UNION over `(SUBSET T) \X (SUBSET O)` so TLAPS can decompose
      members back into their `(t, o)` witness.
    - `OpenPath(G, n, Op)` / `OpenSubGraph(G, n, Op)` — Op-respecting simple
      paths ending at n and the subgraph they induce.
    - `AncestorSubGraph(G, n, Op)` — the closure-based equivalent (ancestors of
      n in the Op-induced subgraph).
    - `RetrySubGraph(G, t, u)` — minimal subgraph placing a fresh node u in
      parallel to t (inherits t's predecessors and successors).
    - `Derivation(G, n, Op, T)` — subgraphs of `AncestorSubGraph` whose only
      sink is n, with sources ⊆ Source(G), and AND-semantics on task inputs.

  - `DDGraphTheorems.tla` + `DDGraphTheorems_proofs.tla` (TLAPS-checked):
    - Structural: `DDG_DDGraphOfMember`, `DDG_DDGraphProperties` (incl. partition
      enlargement), `DDG_EmptyGraphIsDDGraph`, `DDG_BipartiteNeighborhood`.
    - Path/subgraph lifts: `DDG_PathLiftToOpInduced`, `DDG_OpenPathEmpty`.
    - `AncestorSubGraph`: `DDG_AncestorSubGraphBasic`,
      `DDG_AncestorSubGraphProperties` (subgraph of G, DD graph, weakly
      connected, all nodes Op, path-to-target), `DDG_AncestorSubGraphIsMaximal`,
      `DDG_AncestorSubGraphEmpty`, `DDG_OpenSubGraphEqualsAncestorSubGraph`
      (closure and path views agree).
    - Retry: `DDG_RetryUnionIsDag`, `DDG_RetrySubGraphProperties`
      (R is a DD graph, weakly connected, and joining it preserves DD-graph
      status with u added to the task partition).
    - Derivations: `DDG_DerivationProperties` (bundled),
      `DDG_NoDerivationMeansBlockedAncestor` (non-existence criterion).

  - `DDGraphsTests.tla` / `.cfg`: 31 `ASSUME` tests covering every operator
    (incl. cardinalities of `DDGraphOf` on small partitions and the V-shape /
    retry sanity checks). Config overrides `HasDirectedCycle <- MCHasDirectedCycle`
    and `SimplePath <- MCSimplePath` so the downstream operators remain
    enumerable under TLC.

  - `DDGraphs.java`: TLC Java module override providing an efficient bitmask
    enumeration of `DDGraphOf` (the natural set-comprehension form is too
    expensive on partitions of meaningful size).

  - `.gitignore`: ignore `*.class` (Java build artefacts).

  ## Test plan

  - [x] `tlapm` discharges every obligation in `DDGraphTheorems_proofs.tla`.
  - [x] `tlc DDGraphsTests` passes all `ASSUME` assertions.
  - [x] Java override loads (`DDGraphOf` returns the same set as the pure-TLA+
        definition on small partitions).
