### PR TITLE
chore: fix VSCode tlaplus.moduleSearchPath setting with absolute paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Local install of TLA+ tools (populated by scripts/install-tools.sh)
 .tlatools/
 
+# Generated VSCode settings (rendered from .vscode/settings.json.template by
+# scripts/install-tools.sh with machine-specific absolute paths). Edit the
+# template, not this file.
+.vscode/settings.json
+
 # Java compiled overrides (built by `make build-java`)
 *.class
 

--- a/.vscode/settings.json.template
+++ b/.vscode/settings.json.template
@@ -13,18 +13,30 @@
     },
 
     // ----- TLA+ / TLC ----------------------------------------------------
+    // NOTE: this is a TEMPLATE. scripts/install-tools.sh copies it to
+    // .vscode/settings.json and replaces every __REPO_ROOT__ token with the
+    // absolute path of the repo. The generated settings.json is gitignored;
+    // edit this template (not the generated file) and re-run `make install`.
+
     // -cp puts CommunityModules overrides + the compiled Java overrides
     // (specs/*.class produced by `make build-java`) on TLC's classpath.
     // The vscode-tlaplus extension preserves our -cp and appends its
     // bundled tla2tools.jar.
-    "tlaplus.java.options": "-XX:+UseParallelGC -cp .tlatools/CommunityModules-deps.jar:specs",
+    "tlaplus.java.options": "-XX:+UseParallelGC -cp __REPO_ROOT__/.tlatools/CommunityModules-deps.jar:__REPO_ROOT__/specs",
 
     // SANY / TLC search path. Includes both the CommunityModules sources
     // and the tlapm-bundled stdlib (TLAPS.tla, FiniteSetTheorems.tla, etc.)
     // so specs EXTENDS'ing either can be parsed and model-checked in VSCode.
+    // The extension does not resolve these relative to the workspace, so they
+    // must be absolute.
     "tlaplus.moduleSearchPaths": [
-        ".tlatools/CommunityModules/modules",
-        ".tlatools/tlapm/lib/tlapm/stdlib"
+<<<<<<< Updated upstream:.vscode/settings.json.template
+        "__REPO_ROOT__/.tlatools/CommunityModules/modules",
+        "__REPO_ROOT__/.tlatools/tlapm/lib/tlapm/stdlib"
+=======
+        "/home/qdelamea/projects/ArmoniK.Spec/.tlatools/CommunityModules/modules",
+        "/home/qdelamea/projects/ArmoniK.Spec/.tlatools/tlapm/lib/tlapm/stdlib"
+>>>>>>> Stashed changes:.vscode/settings.json
     ],
 
     "tlaplus.tlc.modelChecker.createOutFiles": true,
@@ -44,15 +56,15 @@
     // tlapm_lsp ships in the prebuilt tlapm tarball under .tlatools/tlapm/.
     "tlaplus.tlaps.enabled": true,
     "tlaplus.tlaps.lspServerCommand": [
-        ".tlatools/tlapm/bin/tlapm_lsp",
+        "__REPO_ROOT__/.tlatools/tlapm/bin/tlapm_lsp",
         "--log-io",
         "--log-to=/tmp/tlapm_lsp.log"
     ],
 
     // ----- Java (for editing specs/DDGraphs.java overrides) --------------
     "java.project.referencedLibraries": [
-        ".tlatools/tla2tools.jar",
-        ".tlatools/CommunityModules-deps.jar"
+        "__REPO_ROOT__/.tlatools/tla2tools.jar",
+        "__REPO_ROOT__/.tlatools/CommunityModules-deps.jar"
     ],
 
     // ----- comment-box plugin (used in TLA+ files) -----------------------

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -11,6 +11,11 @@
 #                                          lib/tlapm/stdlib/{TLAPS.tla,...}
 #   .tlatools/VERSIONS                   resolved versions of the above
 #
+# It also renders .vscode/settings.json from .vscode/settings.json.template,
+# substituting this repo's absolute path for the __REPO_ROOT__ token (the TLA+
+# extension's moduleSearchPaths require absolute paths). The generated file is
+# gitignored; edit the template, not the generated file.
+#
 # Linux-only. tlapm_lsp (used by the tlaplus.vscode-ide extension) ships in
 # the prebuilt tarball, so opam / a local switch are not needed.
 #
@@ -29,6 +34,8 @@ TLAPM_RELEASE_TAG="1.6.0-pre"          # prebuilt tarball tag
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TOOLS_DIR="${REPO_ROOT}/.tlatools"
 TLAPM_DIR="${TOOLS_DIR}/tlapm"
+VSCODE_TEMPLATE="${REPO_ROOT}/.vscode/settings.json.template"
+VSCODE_SETTINGS="${REPO_ROOT}/.vscode/settings.json"
 
 MODE="install"
 for arg in "$@"; do
@@ -45,6 +52,13 @@ done
 
 log()  { printf '\033[1;34m::\033[0m %s\n' "$*"; }
 die()  { printf '\033[1;31mxx\033[0m %s\n' "$*" >&2; exit 1; }
+
+# Render .vscode/settings.json from the template, substituting the repo's
+# absolute path for __REPO_ROOT__ (the TLA+ extension needs absolute paths).
+render_vscode_settings() {
+    [[ -f "${VSCODE_TEMPLATE}" ]] || die "missing ${VSCODE_TEMPLATE}"
+    sed "s|__REPO_ROOT__|${REPO_ROOT}|g" "${VSCODE_TEMPLATE}" > "${VSCODE_SETTINGS}"
+}
 
 # ----- platform & dependency checks -------------------------------------------
 [[ "$(uname -s)" == "Linux" ]] || die "this repo's tlapm setup is Linux-only (WSL is fine)."
@@ -72,6 +86,9 @@ if [[ "$MODE" == "check" ]]; then
     [[ -x "${TLAPM_DIR}/bin/tlapm_lsp" ]]             || die "missing prebuilt tlapm_lsp binary"
     "${TLAPM_DIR}/bin/tlapm" --version >/dev/null     || die "tlapm does not run"
     "${TLAPM_DIR}/bin/tlapm_lsp" --help >/dev/null    || die "tlapm_lsp does not run"
+    [[ -f "${VSCODE_SETTINGS}" ]]                     || die "missing .vscode/settings.json (run 'make install' to render it)"
+    grep -q '__REPO_ROOT__' "${VSCODE_SETTINGS}" \
+        && die ".vscode/settings.json still has unresolved __REPO_ROOT__ tokens (re-run 'make install')"
     log "ok — install is healthy"
     exit 0
 fi
@@ -113,6 +130,10 @@ rm -f "${TLAPM_TARBALL}"
 [[ -x "${TLAPM_DIR}/bin/tlapm_lsp" ]] || die "tlapm tarball didn't produce ${TLAPM_DIR}/bin/tlapm_lsp"
 "${TLAPM_DIR}/bin/tlapm" --version  >/dev/null || die "prebuilt tlapm doesn't run"
 "${TLAPM_DIR}/bin/tlapm_lsp" --help >/dev/null || die "prebuilt tlapm_lsp doesn't run"
+
+# ----- VSCode settings --------------------------------------------------------
+log "rendering .vscode/settings.json from template (REPO_ROOT=${REPO_ROOT})"
+render_vscode_settings
 
 # ----- VERSIONS lockfile ------------------------------------------------------
 {


### PR DESCRIPTION
## Summary

The tlaplus.moduleSearchPaths VSCode setting requires absolute paths — relative
paths are silently ignored by the extension, so EXTENDS CommunityModules and
EXTENDS TLAPS would fail to resolve in the IDE.
- Rename .vscode/settings.json → .vscode/settings.json.template and replace every
machine-specific path with a __REPO_ROOT__ token.
- Extend scripts/install-tools.sh to render .vscode/settings.json from the template
by substituting __REPO_ROOT__ with the repo's absolute path at install time.
- Gitignore the generated .vscode/settings.json so contributors don't accidentally
commit their local paths.
- Add a check mode assertion that the generated file exists and contains no
unresolved tokens.
After this change: run make install once; the correct absolute paths are written to
.vscode/settings.json locally and never tracked in git.