### PR TITLE
feat: update DiGraphs and DDGraphs theorems

### DIFF
--- a/specs/DDGraphTheorems.tla
+++ b/specs/DDGraphTheorems.tla
@@ -110,6 +110,20 @@ THEOREM DDG_OpenPathEmpty ==
 --------------------------------------------------------------------------------
 
 (******************************************************************************)
+(* Every open path ending at n lives inside AncestorSubGraph(G, n, Op): it    *)
+(* lifts into the subgraph and stays an open path there (its endpoint is      *)
+(* still n and all its nodes still satisfy Op). The "input" counterpart to   *)
+(* the closure property of DDG_AncestorSubGraphProperties; a corollary of the *)
+(* lift machinery, needing only that G is a directed graph.                   *)
+(******************************************************************************)
+THEOREM DDG_OpenPathInAncestorSubGraph ==
+    ASSUME NEW G, IsDirectedGraph(G), NEW n, NEW Op(_),
+           NEW p \in OpenPath(G, n, Op)
+    PROVE  p \in OpenPath(AncestorSubGraph(G, n, Op), n, Op)
+
+--------------------------------------------------------------------------------
+
+(******************************************************************************)
 (* AncestorSubGraph — structural lemmas.                                      *)
 (*                                                                            *)
 (* The following block builds up the path-to-target property step by step,    *)

--- a/specs/DDGraphTheorems.tla
+++ b/specs/DDGraphTheorems.tla
@@ -181,11 +181,12 @@ THEOREM DDG_AncestorSubGraphEmpty ==
 (* start nodes of open paths ending at n coincides with the set of n's      *)
 (* ancestors in the Op-induced subgraph, and both pin down the same edges.   *)
 (* This lets later proofs switch between the path-based and closure-based   *)
-(* views at will.                                                            *)
+(* views at will. Needs only that G is a directed graph -- the equality is   *)
+(* about simple paths and reachability, so neither finiteness nor the DD     *)
+(* graph structure plays any role.                                          *)
 (******************************************************************************)
 THEOREM DDG_OpenSubGraphEqualsAncestorSubGraph ==
-    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O), NEW n, NEW Op(_),
-           IsFiniteSet(G.node)
+    ASSUME NEW G, IsDirectedGraph(G), NEW n, NEW Op(_)
     PROVE  OpenSubGraph(G, n, Op) = AncestorSubGraph(G, n, Op)
 
 --------------------------------------------------------------------------------

--- a/specs/DDGraphTheorems.tla
+++ b/specs/DDGraphTheorems.tla
@@ -103,8 +103,7 @@ LEMMA DDG_PathLiftToOpInduced ==
 (* not satisfy Op.                                                            *)
 (******************************************************************************)
 THEOREM DDG_OpenPathEmpty ==
-    ASSUME NEW T, NEW O, T \cap O = {},
-           NEW G, IsDDGraph(G, T, O), NEW n \in G.node, NEW Op(_)
+    ASSUME NEW G, NEW n \in G.node, NEW Op(_)
     PROVE  OpenPath(G, n, Op) = {} <=> ~Op(n)
 
 --------------------------------------------------------------------------------
@@ -158,7 +157,7 @@ THEOREM DDG_AncestorSubGraphProperties ==
     (* nodes that fail Op -- A is closed under "Op-passing" upstream traversal.  *)
 (******************************************************************************)
 THEOREM DDG_AncestorSubGraphIsMaximal ==
-    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+    ASSUME NEW G, IsDirectedGraph(G),
            NEW n, NEW Op(_)
     PROVE  LET A == AncestorSubGraph(G, n, Op) IN
            \A m \in A.node : \A x \in Predecessor(G, m) \ A.node : ~Op(x)
@@ -166,12 +165,12 @@ THEOREM DDG_AncestorSubGraphIsMaximal ==
 (******************************************************************************)
 (* Triviality characterization: AncestorSubGraph is empty iff the target n   *)
 (* itself fails Op, and n belongs to A iff Op(n) holds. The two facts are   *)
-(* duals of the same condition Op(n). Requires n \in G.node and finiteness   *)
-(* of G.node (to lift reflexivity of Ancestor through the induced subgraph). *)
+(* duals of the same condition Op(n). Needs only n \in G.node: reflexivity   *)
+(* of Ancestor in the induced subgraph holds for any node, no finiteness or  *)
+(* DD-graph structure required.                                              *)
 (******************************************************************************)
 THEOREM DDG_AncestorSubGraphEmpty ==
-    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
-           NEW n \in G.node, NEW Op(_)
+    ASSUME NEW G, NEW n \in G.node, NEW Op(_)
     PROVE  LET A == AncestorSubGraph(G, n, Op) IN
            /\ A = EmptyGraph <=> ~Op(n)
            /\ n \in A.node <=> Op(n)
@@ -263,7 +262,7 @@ THEOREM DDG_DerivationProperties ==
 (* the criterion quantifies over all ancestors, not over a single path.)     *)
 (******************************************************************************)
 THEOREM DDG_NoDerivationMeansBlockedAncestor ==
-    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+    ASSUME NEW T, NEW G, IsDag(G),
            NEW n \in G.node, NEW Op(_)
     PROVE  Derivation(G, n, Op, T) = {} => \E m \in Ancestor(G, n) : ~Op(m)
 

--- a/specs/DDGraphTheorems.tla
+++ b/specs/DDGraphTheorems.tla
@@ -129,10 +129,10 @@ THEOREM DDG_OpenPathEmpty ==
 (******************************************************************************)
 THEOREM DDG_AncestorSubGraphProperties ==
     ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
-           NEW n \in O, NEW Op(_),
-           \A t \in G.node \cap T : Op(t) => \A x \in Predecessor(G, t) : Op(x)
+           NEW n \in O, NEW Op(_)
     PROVE  LET A == AncestorSubGraph(G, n, Op) IN
-           /\ IsDDGraph(A, T, O)
+           /\ (\A t \in G.node \cap T : Op(t) => \A x \in Predecessor(G, t) : Op(x))
+              => IsDDGraph(A, T, O)
            /\ A \in DirectedSubgraph(G)
            /\ IsWeaklyConnected(A)
            /\ \A m \in A.node : Op(m)

--- a/specs/DDGraphTheorems_proofs.tla
+++ b/specs/DDGraphTheorems_proofs.tla
@@ -571,15 +571,96 @@ THEOREM DDG_AncestorSubGraphEmpty ==
     BY <1>5, <1>6
 
 (******************************************************************************)
-(* Still admitted: OpenSubGraphEquals needs the equality of the OpenPath-     *)
-(* start node set and the Ancestor node set in the Op-induced subgraph        *)
-(* (the path-based vs. closure-based views coincide).                         *)
+(* OpenSubGraphEquals: the OpenPath-start node set equals the Ancestor node   *)
+(* set in the Op-induced subgraph, so the path-based and closure-based views  *)
+(* coincide. The forward inclusion is exactly DDG_OpenPathInAncestorSubGraph; *)
+(* the converse lifts an Op-induced simple path back to G as an open path.    *)
+(* Needs only IsDirectedGraph(G).                                            *)
 (******************************************************************************)
 THEOREM DDG_OpenSubGraphEqualsAncestorSubGraph ==
-    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O), NEW n, NEW Op(_),
-           IsFiniteSet(G.node)
+    ASSUME NEW G, IsDirectedGraph(G), NEW n, NEW Op(_)
     PROVE  OpenSubGraph(G, n, Op) = AncestorSubGraph(G, n, Op)
-PROOF OMITTED
+<1> DEFINE InducedNodes == {y \in G.node : Op(y)}
+<1> DEFINE InducedGraph == [node |-> InducedNodes,
+                            edge |-> G.edge \cap (InducedNodes \X InducedNodes)]
+<1> DEFINE OSGN == {p[1] : p \in OpenPath(G, n, Op)}
+<1> DEFINE ASGN == IF n \in InducedNodes THEN Ancestor(InducedGraph, n) ELSE {}
+<1>1. OSGN = ASGN
+    <2>1. CASE n \notin InducedNodes
+        <3>1. ASGN = {}
+            BY <2>1
+        <3>2. OSGN = {}
+            <4> SUFFICES ASSUME NEW y \in OSGN PROVE FALSE
+                OBVIOUS
+            <4>1. PICK p \in OpenPath(G, n, Op) : p[1] = y
+                OBVIOUS
+            <4>2. p \in SimplePath(G) /\ p[Len(p)] = n /\ \A i \in 1..Len(p) : Op(p[i])
+                BY <4>1 DEF OpenPath
+            <4>3. p \in Seq(G.node) /\ Len(p) \in 1..Len(p)
+                BY <4>2, DG_SimplePathIsSeq
+            <4>4. n \in G.node /\ Op(n)
+                BY <4>2, <4>3, ElementOfSeq
+            <4>. QED
+                BY <4>4, <2>1
+        <3>. QED
+            BY <3>1, <3>2
+    <2>2. CASE n \in InducedNodes
+        <3>1. ASGN = Ancestor(InducedGraph, n)
+            BY <2>2
+        <3>2. OSGN \subseteq Ancestor(InducedGraph, n)
+            <4> SUFFICES ASSUME NEW y \in OSGN
+                         PROVE  y \in Ancestor(InducedGraph, n)
+                OBVIOUS
+            <4>1. PICK p \in OpenPath(G, n, Op) : p[1] = y
+                OBVIOUS
+            <4>2. p \in OpenPath(AncestorSubGraph(G, n, Op), n, Op)
+                BY <4>1, DDG_OpenPathInAncestorSubGraph
+            <4>3. p \in SimplePath(AncestorSubGraph(G, n, Op))
+                BY <4>2 DEF OpenPath
+            <4>4. AncestorSubGraph(G, n, Op).node = Ancestor(InducedGraph, n)
+                BY <2>2 DEF AncestorSubGraph
+            <4>5. p \in Seq(AncestorSubGraph(G, n, Op).node) /\ 1 \in 1..Len(p)
+                BY <4>3, DG_SimplePathIsSeq
+            <4>6. p[1] \in AncestorSubGraph(G, n, Op).node
+                BY <4>5, ElementOfSeq
+            <4>. QED
+                BY <4>6, <4>4, <4>1
+        <3>3. Ancestor(InducedGraph, n) \subseteq OSGN
+            <4> SUFFICES ASSUME NEW y \in Ancestor(InducedGraph, n)
+                         PROVE  y \in OSGN
+                OBVIOUS
+            <4>1. PICK q \in SimplePath(InducedGraph) : q[1] = y /\ q[Len(q)] = n
+                BY DEF Ancestor, AreConnectedIn
+            <4>2. q \in Seq(InducedGraph.node) /\ Len(q) \in Nat /\ Len(q) >= 1
+                  /\ \A i \in 1..(Len(q) - 1) : <<q[i], q[i+1]>> \in InducedGraph.edge
+                BY <4>1, DG_SimplePathIsSeq
+            <4>3. \A i \in 1..Len(q) : q[i] \in G.node /\ Op(q[i])
+                <5> SUFFICES ASSUME NEW i \in 1..Len(q)
+                             PROVE  q[i] \in G.node /\ Op(q[i])
+                    OBVIOUS
+                <5>1. q[i] \in InducedGraph.node
+                    BY <4>2, ElementOfSeq
+                <5>. QED
+                    BY <5>1
+            <4>4. \A i \in 1..(Len(q) - 1) : <<q[i], q[i+1]>> \in G.edge
+                BY <4>2
+            <4>5. q \in SimplePath(G)
+                BY <4>1, <4>3, <4>4, DG_SimplePathLift
+            <4>6. q \in OpenPath(G, n, Op)
+                BY <4>5, <4>1, <4>3 DEF OpenPath
+            <4>. QED
+                BY <4>6, <4>1
+        <3>. QED
+            BY <3>1, <3>2, <3>3
+    <2>. QED
+        BY <2>1, <2>2
+<1>. QED
+    <2>1. OpenSubGraph(G, n, Op) = [node |-> OSGN, edge |-> G.edge \cap (OSGN \X OSGN)]
+        BY DEF OpenSubGraph
+    <2>2. AncestorSubGraph(G, n, Op) = [node |-> ASGN, edge |-> G.edge \cap (ASGN \X ASGN)]
+        BY DEF AncestorSubGraph
+    <2>. QED
+        BY <1>1, <2>1, <2>2
 
 THEOREM DDG_RetryUnionIsDag ==
     ASSUME NEW G, IsDag(G), NEW t \in G.node, NEW u, u \notin G.node

--- a/specs/DDGraphTheorems_proofs.tla
+++ b/specs/DDGraphTheorems_proofs.tla
@@ -246,6 +246,52 @@ THEOREM DDG_OpenPathEmpty ==
 <1>. QED
     BY <1>1, <1>2
 
+THEOREM DDG_OpenPathInAncestorSubGraph ==
+    ASSUME NEW G, IsDirectedGraph(G), NEW n, NEW Op(_),
+           NEW p \in OpenPath(G, n, Op)
+    PROVE  p \in OpenPath(AncestorSubGraph(G, n, Op), n, Op)
+<1> DEFINE InducedNodes == {y \in G.node : Op(y)}
+<1> DEFINE InducedGraph == [node |-> InducedNodes,
+                            edge |-> G.edge \cap (InducedNodes \X InducedNodes)]
+<1> DEFINE A == AncestorSubGraph(G, n, Op)
+<1>1. p \in SimplePath(G) /\ p[Len(p)] = n /\ \A i \in 1..Len(p) : Op(p[i])
+    BY DEF OpenPath
+<1>2. p \in SimplePath(InducedGraph)
+    BY <1>1, DDG_PathLiftToOpInduced
+<1>3. n \in InducedNodes
+    <2>1. p \in Seq(G.node) /\ Len(p) \in 1..Len(p)
+        BY <1>1, DG_SimplePathIsSeq
+    <2>2. p[Len(p)] \in G.node /\ Op(p[Len(p)])
+        BY <1>1, <2>1, ElementOfSeq
+    <2>. QED
+        BY <1>1, <2>2
+<1>4. A = [node |-> Ancestor(InducedGraph, n),
+           edge |-> G.edge \cap (Ancestor(InducedGraph, n) \X Ancestor(InducedGraph, n))]
+    BY <1>3 DEF AncestorSubGraph
+<1>5. \A i \in 1..Len(p) : p[i] \in A.node
+    <2> SUFFICES ASSUME NEW i \in 1..Len(p) PROVE p[i] \in A.node
+        OBVIOUS
+    <2>1. IsDirectedGraph(InducedGraph)
+        BY DEF IsDirectedGraph
+    <2>2. p[i] \in Ancestor(InducedGraph, p[Len(p)])
+        BY <1>2, <2>1, DG_AncestorOnPath
+    <2>. QED
+        BY <2>2, <1>1, <1>4
+<1>6. \A i \in 1..(Len(p) - 1) : <<p[i], p[i+1]>> \in A.edge
+    <2> SUFFICES ASSUME NEW i \in 1..(Len(p) - 1)
+                 PROVE  <<p[i], p[i+1]>> \in A.edge
+        OBVIOUS
+    <2>1. <<p[i], p[i+1]>> \in G.edge /\ i \in 1..Len(p) /\ i+1 \in 1..Len(p)
+        BY <1>1, DG_SimplePathIsSeq
+    <2>2. p[i] \in A.node /\ p[i+1] \in A.node
+        BY <2>1, <1>5
+    <2>. QED
+        BY <2>1, <2>2, <1>4
+<1>7. p \in SimplePath(A)
+    BY <1>1, <1>5, <1>6, DG_SimplePathLift
+<1>. QED
+    BY <1>7, <1>1 DEF OpenPath
+
 THEOREM DDG_AncestorSubGraphProperties ==
     ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
            NEW n \in O, NEW Op(_)

--- a/specs/DDGraphTheorems_proofs.tla
+++ b/specs/DDGraphTheorems_proofs.tla
@@ -219,15 +219,14 @@ LEMMA DDG_PathLiftToOpInduced ==
 (******************************************************************************)
 
 THEOREM DDG_OpenPathEmpty ==
-    ASSUME NEW T, NEW O, T \cap O = {},
-           NEW G, IsDDGraph(G, T, O), NEW n \in G.node, NEW Op(_)
+    ASSUME NEW G, NEW n \in G.node, NEW Op(_)
     PROVE  OpenPath(G, n, Op) = {} <=> ~Op(n)
 <1>1. OpenPath(G, n, Op) = {} => ~Op(n)
     <2>. SUFFICES ASSUME OpenPath(G, n, Op) = {}, Op(n)
                   PROVE FALSE
         OBVIOUS
     <2>1. <<n>> \in SimplePath(G)
-        BY DG_TrivialPath, DDG_DDGraphProperties
+        BY DG_TrivialPath
     <2>. QED
         BY <2>1 DEF OpenPath
 <1>2. ~Op(n) => OpenPath(G, n, Op) = {}
@@ -456,7 +455,7 @@ THEOREM DDG_AncestorSubGraphProperties ==
     BY <1>7, <1>5, <1>8, <1>4, <1>6
 
 THEOREM DDG_AncestorSubGraphIsMaximal ==
-    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+    ASSUME NEW G, IsDirectedGraph(G),
            NEW n, NEW Op(_)
     PROVE  LET A == AncestorSubGraph(G, n, Op) IN
            \A m \in A.node : \A x \in Predecessor(G, m) \ A.node : ~Op(x)
@@ -483,7 +482,7 @@ THEOREM DDG_AncestorSubGraphIsMaximal ==
 <1>7. m \in Ancestor(InducedGraph, n)
     BY <1>4, <1>6
 <1>8. IsDirectedGraph(G)
-    BY DEF IsDDGraph, IsDag
+    OBVIOUS
 <1>9. <<x, m>> \in G.edge /\ x \in G.node /\ m \in G.node
     BY <1>3, <1>8 DEF Predecessor, IsDirectedGraph
 <1>10. x \in InducedNodes
@@ -512,8 +511,7 @@ THEOREM DDG_AncestorSubGraphIsMaximal ==
     BY <1>17, <1>3
 
 THEOREM DDG_AncestorSubGraphEmpty ==
-    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
-           NEW n \in G.node, NEW Op(_)
+    ASSUME NEW G, NEW n \in G.node, NEW Op(_)
     PROVE  LET A == AncestorSubGraph(G, n, Op) IN
            /\ A = EmptyGraph <=> ~Op(n)
            /\ n \in A.node <=> Op(n)
@@ -1075,7 +1073,7 @@ THEOREM DDG_DerivationProperties ==
     BY <1>6, <1>8, <1>4, <1>7
 
 THEOREM DDG_NoDerivationMeansBlockedAncestor ==
-    ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
+    ASSUME NEW T, NEW G, IsDag(G),
            NEW n \in G.node, NEW Op(_)
     PROVE  Derivation(G, n, Op, T) = {} => \E m \in Ancestor(G, n) : ~Op(m)
 (* Contrapositive: if every ancestor of n is Op, the ancestor-induced        *)
@@ -1097,7 +1095,7 @@ THEOREM DDG_NoDerivationMeansBlockedAncestor ==
       /\ IsDirectedGraph(A)
       /\ IsDirectedGraph(InducedGraph)
     <2>1. IsDirectedGraph(G) /\ IsDag(G)
-        BY DEF IsDDGraph, IsDag
+        BY DEF IsDag
     <2>2. Anc \subseteq G.node /\ n \in Anc
         BY <2>1, DG_AncestorDescendantProperties
     <2>3. IsDirectedGraph(A)

--- a/specs/DDGraphTheorems_proofs.tla
+++ b/specs/DDGraphTheorems_proofs.tla
@@ -248,10 +248,10 @@ THEOREM DDG_OpenPathEmpty ==
 
 THEOREM DDG_AncestorSubGraphProperties ==
     ASSUME NEW T, NEW O, NEW G, IsDDGraph(G, T, O),
-           NEW n \in O, NEW Op(_),
-           \A t \in G.node \cap T : Op(t) => \A x \in Predecessor(G, t) : Op(x)
+           NEW n \in O, NEW Op(_)
     PROVE  LET A == AncestorSubGraph(G, n, Op) IN
-           /\ IsDDGraph(A, T, O)
+           /\ (\A t \in G.node \cap T : Op(t) => \A x \in Predecessor(G, t) : Op(x))
+              => IsDDGraph(A, T, O)
            /\ A \in DirectedSubgraph(G)
            /\ IsWeaklyConnected(A)
            /\ \A m \in A.node : Op(m)
@@ -335,7 +335,11 @@ THEOREM DDG_AncestorSubGraphProperties ==
     <2>. QED
         BY <2>3, <2>7 DEF AreConnectedIn
 (* Conjunct 1: A is a DD graph over (T, O) *)
-<1>7. IsDDGraph(A, T, O)
+<1>7. (\A t \in G.node \cap T : Op(t) => \A x \in Predecessor(G, t) : Op(x))
+      => IsDDGraph(A, T, O)
+    <2> SUFFICES ASSUME \A t \in G.node \cap T : Op(t) => \A x \in Predecessor(G, t) : Op(x)
+                 PROVE  IsDDGraph(A, T, O)
+        OBVIOUS
     <2>1. IsBipartiteWithPartitions(G, T, O)
         BY DEF IsDDGraph
     <2>2. IsDag(A) /\ IsBipartiteWithPartitions(A, T, O)

--- a/specs/DiGraphTheorems.tla
+++ b/specs/DiGraphTheorems.tla
@@ -132,8 +132,8 @@ THEOREM DG_TrivialPath ==
 
 (******************************************************************************)
 (* Reflexivity of connectivity: the single-node sequence <<n>> witnesses      *)
-(* AreConnectedIn(G, n, n) for every node n of a finite-node graph. Stated   *)
-(* as its own theorem because it is reused inside other proofs.               *)
+(* AreConnectedIn(G, n, n) for every node n of G (no finiteness needed).      *)
+(* Stated as its own theorem because it is reused inside other proofs.         *)
 (******************************************************************************)
 THEOREM DG_AreConnectedReflexive ==
     ASSUME NEW G, NEW n \in G.node
@@ -151,7 +151,8 @@ THEOREM DG_EdgeConnects ==
 
 (******************************************************************************)
 (* Ancestor / Descendant properties: both sets are subsets of G.node, they    *)
-(* are dual to each other, and they are reflexive on finite-node graphs.      *)
+(* are dual to each other, and they are reflexive (n is its own ancestor and  *)
+(* descendant) -- no finiteness needed.                                       *)
 (******************************************************************************)
 THEOREM DG_AncestorDescendantProperties ==
     ASSUME NEW G, NEW m \in G.node, NEW n \in G.node
@@ -194,7 +195,7 @@ LEMMA DG_PathConcat ==
 (* The ancestor set is closed under taking predecessors: if m reaches n and  *)
 (* x has an edge to m in G, then x also reaches n. Prepending x to a simple *)
 (* path from m to n yields a path, which is then shortened back to a simple *)
-(* path via DG_PathHasSimplePath -- whence the finiteness hypothesis.          *)
+(* path via DG_PathHasSimplePath (needs only IsDirectedGraph, no finiteness). *)
 (******************************************************************************)
 THEOREM DG_AncestorClosedUnderPredecessor ==
     ASSUME NEW G, IsDirectedGraph(G),
@@ -268,14 +269,14 @@ LEMMA DG_PathReverse ==
 (******************************************************************************)
 THEOREM DG_UUGReachabilitySymmetric ==
     ASSUME NEW G, IsDirectedGraph(G),
-           NEW a \in G.node, NEW b \in G.node,
+           NEW a, NEW b,
            AreConnectedIn(UnderlyingUndirectedGraph(G), a, b)
     PROVE  AreConnectedIn(UnderlyingUndirectedGraph(G), b, a)
 
 (******************************************************************************)
-(* Transitivity of reachability in a finite-node directed graph: combining   *)
-(* simple paths a -> b and b -> c via path concatenation followed by         *)
-(* DG_PathHasSimplePath gives a simple path a -> c.                              *)
+(* Transitivity of reachability in a directed graph: combining simple paths   *)
+(* a -> b and b -> c via path concatenation followed by DG_PathHasSimplePath  *)
+(* gives a simple path a -> c (no finiteness needed).                          *)
 (******************************************************************************)
 THEOREM DG_AreConnectedTransitive ==
     ASSUME NEW G, IsDirectedGraph(G),

--- a/specs/DiGraphTheorems.tla
+++ b/specs/DiGraphTheorems.tla
@@ -345,6 +345,7 @@ THEOREM DG_EmptyGraphProperties ==
     /\ \A U, V : U \cap V = {} => IsBipartiteWithPartitions(EmptyGraph, U, V)
     /\ Source(EmptyGraph) = {}
     /\ Sink(EmptyGraph) = {}
+    /\ \A G: IsDirectedGraph(G) => (G.node = {} <=> G = EmptyGraph)
 
 (******************************************************************************)
 (* Properties of DAGs: a DAG is in particular a well-formed directed graph,   *)

--- a/specs/DiGraphTheorems_proofs.tla
+++ b/specs/DiGraphTheorems_proofs.tla
@@ -295,6 +295,7 @@ THEOREM DG_EmptyGraphProperties ==
     /\ \A U, V : U \cap V = {} => IsBipartiteWithPartitions(EmptyGraph, U, V)
     /\ Source(EmptyGraph) = {}
     /\ Sink(EmptyGraph) = {}
+    /\ \A G: IsDirectedGraph(G) => (G.node = {} <=> G = EmptyGraph)
 <1>1. IsDirectedGraph(EmptyGraph)
     BY DEF EmptyGraph, IsDirectedGraph
 <1>2. \A S : EmptyGraph \in DirectedGraphOf(S)
@@ -317,8 +318,14 @@ THEOREM DG_EmptyGraphProperties ==
     BY DEF EmptyGraph, Source, Predecessor
 <1>6. Sink(EmptyGraph) = {}
     BY DEF EmptyGraph, Sink, Successor
+<1>7. \A G: IsDirectedGraph(G) => (G.node = {} <=> G = EmptyGraph)
+    <2>. SUFFICES ASSUME NEW G, IsDirectedGraph(G)
+         PROVE G.node = {} <=> G = EmptyGraph
+        OBVIOUS
+    <2>. QED
+        BY DEF IsDirectedGraph, EmptyGraph
 <1>. QED
-    BY <1>1, <1>2, <1>3, <1>4, <1>5, <1>6
+    BY <1>1, <1>2, <1>3, <1>4, <1>5, <1>6, <1>7
 
 (******************************************************************************)
 (* DAG properties: being a directed graph and having no self-loop.            *)

--- a/specs/DiGraphTheorems_proofs.tla
+++ b/specs/DiGraphTheorems_proofs.tla
@@ -449,7 +449,7 @@ LEMMA DG_PathReverse ==
 (******************************************************************************)
 THEOREM DG_UUGReachabilitySymmetric ==
     ASSUME NEW G, IsDirectedGraph(G),
-           NEW a \in G.node, NEW b \in G.node,
+           NEW a, NEW b,
            AreConnectedIn(UnderlyingUndirectedGraph(G), a, b)
     PROVE  AreConnectedIn(UnderlyingUndirectedGraph(G), b, a)
 <1> DEFINE UUG == UnderlyingUndirectedGraph(G)

--- a/specs/DiGraphTheorems_proofs.tla
+++ b/specs/DiGraphTheorems_proofs.tla
@@ -322,8 +322,10 @@ THEOREM DG_EmptyGraphProperties ==
     <2>. SUFFICES ASSUME NEW G, IsDirectedGraph(G)
          PROVE G.node = {} <=> G = EmptyGraph
         OBVIOUS
+    <2>1. G.node = {} <=> (G.node \X G.node) = {}
+        OBVIOUS
     <2>. QED
-        BY DEF IsDirectedGraph, EmptyGraph
+        BY <2>1 DEF IsDirectedGraph, EmptyGraph
 <1>. QED
     BY <1>1, <1>2, <1>3, <1>4, <1>5, <1>6, <1>7
 


### PR DESCRIPTION
## Summary

This branch strengthens the DDGraph / DiGraph theorem library by minimizing
hypotheses on several key theorems — replacing overly strong IsDDGraph /
IsFiniteSet / IsDag assumptions with the weakest structure actually needed — and
adds one new theorem bridging the path-based and closure-based views of
AncestorSubGraph.

### New theorem:
- DDG_OpenPathInAncestorSubGraph — every open path ending at n in G is also an open path in AncestorSubGraph(G, n, Op). Needs only IsDirectedGraph(G); no finiteness or DD-graph structure required.

### Hypothesis minimizations
* Theorem: DDG_OpenPathEmpty
    * Before: IsDDGraph(G, T, O), T ∩ O = {}, n ∈ G.node
    * After: none (only n ∈ G.node, Op(_))
* Theorem: DDG_AncestorSubGraphProperties
    * Before: Op-monotonicity as ASSUME hypothesis
    * After: moved inside conclusion as antecedent of IsDDGraph(A,T,O) conjunct
* Theorem: DDG_AncestorSubGraphIsMaximal
    * Before: IsDDGraph(G, T, O)
    * After: IsDirectedGraph(G)
* Theorem: DDG_AncestorSubGraphEmpty
    * Before: IsDDGraph(G, T, O), finiteness
    * After: none (only n ∈ G.node)
* Theorem: DDG_OpenSubGraphEqualsAncestorSubGraph
    * Before: IsDDGraph(G, T, O), IsFiniteSet(G.node)
    * After: IsDirectedGraph(G)
* Theorem: DDG_NoDerivationMeansBlockedAncestor
    * Before: IsDDGraph(G, T, O)
    * After: IsDag(G)
* Theorem: DG_UUGReachabilitySymmetric
    * Before: a ∈ G.node, b ∈ G.node
    * After: dropped (membership not needed)

### Other changes
- DG_EmptyGraphProperties gains a new conjunct: IsDirectedGraph(G) ⇒ (G.node = {} ⟺ G = EmptyGraph).
- Stale comments referencing dropped finiteness/DD-graph hypotheses updated
throughout.