### PR TITLE
feat: Complete the RefineObjectProcessing1 liveness refinement proof for GraphProcessing1

### DIFF
--- a/specs/DDGraphTheorems.tla
+++ b/specs/DDGraphTheorems.tla
@@ -190,6 +190,56 @@ THEOREM DDG_OpenSubGraphEqualsAncestorSubGraph ==
 
 --------------------------------------------------------------------------------
 (******************************************************************************)
+(* MaximalOpenPath -- existence and the suffix characterisation.              *)
+(******************************************************************************)
+
+(******************************************************************************)
+(* Prepending an Op-satisfying predecessor u of the root p[1] of an open path  *)
+(* to n yields an open path to n one node longer. u is not already on p (else  *)
+(* p[1] reaches u and u -> p[1] closes a directed cycle), so the extended      *)
+(* sequence stays simple.                                                      *)
+(******************************************************************************)
+LEMMA DDG_PrependOpenPath ==
+    ASSUME NEW G, IsDag(G), NEW n, NEW Op(_),
+           NEW p \in OpenPath(G, n, Op),
+           NEW u \in Predecessor(G, p[1]), Op(u)
+    PROVE  /\ (<<u>> \o p) \in OpenPath(G, n, Op)
+           /\ Len(<<u>> \o p) = Len(p) + 1
+
+(******************************************************************************)
+(* A maximal open path to n exists whenever some open path to n does: a        *)
+(* longest open path (lengths are bounded by Cardinality(G.node)) has a root   *)
+(* with no Op-predecessor, since prepending one (DDG_PrependOpenPath) would    *)
+(* give a strictly longer open path.                                           *)
+(******************************************************************************)
+THEOREM DDG_MaximalOpenPathExists ==
+    ASSUME NEW G, IsDag(G), IsFiniteSet(G.node),
+           NEW n, NEW Op(_), OpenPath(G, n, Op) # {}
+    PROVE  MaximalOpenPath(G, n, Op) # {}
+
+(******************************************************************************)
+(* IsStrictSuffix in concrete terms: a strict suffix is strictly shorter and  *)
+(* aligns with the tail of the longer sequence. Derived from IsStrictPrefix on *)
+(* the reversed sequences (IsSuffix is IsPrefix of the reverses).             *)
+(******************************************************************************)
+LEMMA DDG_StrictSuffixChar ==
+    ASSUME NEW S, NEW s \in Seq(S), NEW t \in Seq(S), IsStrictSuffix(s, t)
+    PROVE  /\ Len(s) < Len(t)
+           /\ \A i \in 1..Len(s) : s[i] = t[(Len(t) - Len(s)) + i]
+
+(******************************************************************************)
+(* On a DAG, the "root has no Op-predecessor" characterisation of             *)
+(* MaximalOpenPath coincides with the order-theoretic one: an open path is    *)
+(* maximal iff it is not a proper (strict) suffix of any other open path.     *)
+(******************************************************************************)
+THEOREM DDG_MaximalOpenPathSuffixEquiv ==
+    ASSUME NEW G, IsDag(G), NEW n, NEW Op(_)
+    PROVE  MaximalOpenPath(G, n, Op) =
+           {p \in OpenPath(G, n, Op) :
+                \A q \in OpenPath(G, n, Op) : ~ IsStrictSuffix(p, q)}
+
+--------------------------------------------------------------------------------
+(******************************************************************************)
 (* RetrySubGraph — retry attachment is safe.                                  *)
 (******************************************************************************)
 

--- a/specs/DDGraphTheorems_proofs.tla
+++ b/specs/DDGraphTheorems_proofs.tla
@@ -10,7 +10,7 @@
 (******************************************************************************)
 
 EXTENDS DDGraphs, DiGraphTheorems, FiniteSetTheorems, FiniteSetsExtTheorems,
-        FunctionTheorems, SequenceTheorems, TLAPS
+        FunctionTheorems, SequenceTheorems, SequencesExtTheorems, TLAPS
 
 (******************************************************************************)
 (* Every member of DDGraphOf(T, O) is a DD graph over T and O, with nodes in *)
@@ -659,6 +659,523 @@ THEOREM DDG_OpenSubGraphEqualsAncestorSubGraph ==
         BY DEF AncestorSubGraph
     <2>. QED
         BY <1>1, <2>1, <2>2
+
+(******************************************************************************)
+(* MaximalOpenPath -- existence and the suffix characterisation.              *)
+(******************************************************************************)
+
+(******************************************************************************)
+(* Prepending an Op-satisfying predecessor u of the root p[1] of an open path  *)
+(* to n yields an open path to n one node longer. u is not already on p (else  *)
+(* p[1] reaches u and u -> p[1] closes a directed cycle), so the extended      *)
+(* sequence stays simple.                                                      *)
+(******************************************************************************)
+LEMMA DDG_PrependOpenPath ==
+    ASSUME NEW G, IsDag(G), NEW n, NEW Op(_),
+           NEW p \in OpenPath(G, n, Op),
+           NEW u \in Predecessor(G, p[1]), Op(u)
+    PROVE  /\ (<<u>> \o p) \in OpenPath(G, n, Op)
+           /\ Len(<<u>> \o p) = Len(p) + 1
+<1>1. IsDirectedGraph(G)
+    BY DEF IsDag
+<1>p. /\ p \in SimplePath(G) /\ p \in Seq(G.node) /\ p[Len(p)] = n
+      /\ (\A i \in 1..Len(p) : Op(p[i]))
+      /\ Len(p) \in Nat /\ Len(p) >= 1 /\ DOMAIN p = 1..Len(p)
+      /\ IsInjective(p)
+    BY DG_SimplePathIsSeq DEF OpenPath
+<1>e. <<u, p[1]>> \in G.edge /\ u \in G.node
+    BY DEF Predecessor
+<1> DEFINE q == <<u>> \o p
+<1>2. /\ q \in Seq(G.node)
+      /\ Len(q) = Len(p) + 1
+      /\ q[1] = u
+      /\ \A i \in 2..(Len(p) + 1) : q[i] = p[i-1]
+    <2>1. <<u>> \in Seq(G.node) /\ Len(<<u>>) = 1
+        BY <1>e
+    <2>2. /\ q \in Seq(G.node)
+          /\ Len(q) = 1 + Len(p)
+          /\ \A i \in 1..(1 + Len(p)) :
+                q[i] = IF i <= 1 THEN <<u>>[i] ELSE p[i-1]
+        BY <2>1, <1>p, ConcatProperties
+    <2>. QED
+        BY <2>2, <1>p
+<1>3. \A j \in 1..Len(p) : p[j] # u
+    <2> SUFFICES ASSUME NEW j \in 1..Len(p), p[j] = u
+                 PROVE  FALSE
+        OBVIOUS
+    <2> DEFINE pre == [i \in 1..j |-> p[i]]
+    <2>1. j \in Nat /\ j >= 1 /\ j <= Len(p)
+        BY <1>p
+    <2>2. /\ pre \in Seq(G.node) /\ Len(pre) = j /\ DOMAIN pre = 1..j
+          /\ \A i \in 1..j : pre[i] = p[i]
+        <3>1. \A i \in 1..j : p[i] \in G.node
+            BY <1>p, <2>1, ElementOfSeq
+        <3>2. pre \in Seq(G.node)
+            BY <3>1, <2>1, IsASeq, Isa
+        <3>3. DOMAIN pre = 1..j /\ \A i \in 1..j : pre[i] = p[i]
+            OBVIOUS
+        <3>4. Len(pre) = j
+            BY <3>2, <3>3, <2>1, LenProperties
+        <3>. QED
+            BY <3>2, <3>3, <3>4
+    <2>3. pre \in SimplePath(G)
+        <3>1. pre # <<>> /\ Len(pre) >= 1
+            BY <2>2, <2>1
+        <3>2. \A i \in 1..(Len(pre) - 1) : <<pre[i], pre[i+1]>> \in G.edge
+            <4> SUFFICES ASSUME NEW i \in 1..(Len(pre) - 1)
+                         PROVE  <<pre[i], pre[i+1]>> \in G.edge
+                OBVIOUS
+            <4>1. i \in 1..j /\ i + 1 \in 1..j
+                BY <2>2, <2>1
+            <4>2. pre[i] = p[i] /\ pre[i+1] = p[i+1]
+                BY <4>1, <2>2
+            <4>3. i \in 1..(Len(p) - 1)
+                BY <4>1, <2>1, <1>p
+            <4>. QED
+                BY <4>2, <4>3, <1>p DEF SimplePath, Path
+        <3>3. pre \in Path(G)
+            BY <2>2, <3>1, <3>2 DEF Path
+        <3>4. IsInjective(pre)
+            <4> SUFFICES ASSUME NEW a \in DOMAIN pre, NEW b \in DOMAIN pre,
+                                pre[a] = pre[b]
+                         PROVE  a = b
+                BY DEF IsInjective
+            <4>1. DOMAIN pre = 1..j
+                BY <2>2, LenProperties
+            <4>2. a \in 1..j /\ b \in 1..j /\ pre[a] = p[a] /\ pre[b] = p[b]
+                BY <4>1, <2>2
+            <4>3. a \in 1..Len(p) /\ b \in 1..Len(p)
+                BY <4>2, <2>1, <1>p
+            <4>. QED
+                BY <4>2, <4>3, <1>p DEF SimplePath, IsInjective
+        <3>. QED
+            BY <3>3, <3>4 DEF SimplePath
+    <2>4. pre[1] = p[1] /\ pre[Len(pre)] = u
+        BY <2>2, <2>1
+    <2>5. AreConnectedIn(G, p[1], u)
+        BY <2>3, <2>4 DEF AreConnectedIn
+    <2>. QED
+        BY <2>5, <1>e, DG_DagNoBackEdge
+<1>4. q \in SimplePath(G)
+    <2>1. q \in Path(G)
+        <3>1. q # <<>> /\ Len(q) >= 1
+            BY <1>2, <1>p
+        <3>2. \A i \in 1..(Len(q) - 1) : <<q[i], q[i+1]>> \in G.edge
+            <4> SUFFICES ASSUME NEW i \in 1..(Len(q) - 1)
+                         PROVE  <<q[i], q[i+1]>> \in G.edge
+                OBVIOUS
+            <4>1. i \in Nat /\ i >= 1 /\ i <= Len(p)
+                BY <3>1, <1>2, <1>p
+            <4>2. CASE i = 1
+                <5>1. q[1] = u /\ q[2] = p[1]
+                    BY <1>2, <1>p
+                <5>. QED
+                    BY <4>2, <5>1, <1>e
+            <4>3. CASE i >= 2
+                <5>1. q[i] = p[i-1] /\ q[i+1] = p[i]
+                    BY <1>2, <4>1, <4>3, <1>p
+                <5>2. i - 1 \in 1..(Len(p) - 1)
+                    BY <4>1, <4>3, <1>p
+                <5>. QED
+                    BY <5>1, <5>2, <1>p DEF SimplePath, Path
+            <4>. QED
+                BY <4>1, <4>2, <4>3
+        <3>. QED
+            BY <1>2, <3>1, <3>2 DEF Path
+    <2>2. IsInjective(q)
+        <3> SUFFICES ASSUME NEW a \in DOMAIN q, NEW b \in DOMAIN q,
+                            q[a] = q[b]
+                     PROVE  a = b
+            BY DEF IsInjective
+        <3>1. DOMAIN q = 1..Len(q) /\ a \in 1..Len(q) /\ b \in 1..Len(q)
+            BY <1>2, LenProperties
+        <3>2. /\ a \in Nat /\ b \in Nat /\ a >= 1 /\ b >= 1
+              /\ a <= Len(p) + 1 /\ b <= Len(p) + 1
+            BY <3>1, <1>2, <1>p
+        <3>3. CASE a = 1 /\ b = 1
+            BY <3>3
+        <3>4. CASE a = 1 /\ b >= 2
+            <4>1. q[a] = u /\ q[b] = p[b-1] /\ b - 1 \in 1..Len(p)
+                BY <1>2, <3>2, <3>4, <1>p
+            <4>. QED
+                BY <4>1, <1>3
+        <3>5. CASE b = 1 /\ a >= 2
+            <4>1. q[b] = u /\ q[a] = p[a-1] /\ a - 1 \in 1..Len(p)
+                BY <1>2, <3>2, <3>5, <1>p
+            <4>. QED
+                BY <4>1, <1>3
+        <3>6. CASE a >= 2 /\ b >= 2
+            <4>1. q[a] = p[a-1] /\ q[b] = p[b-1]
+                BY <1>2, <3>2, <3>6
+            <4>2. a - 1 \in 1..Len(p) /\ b - 1 \in 1..Len(p)
+                BY <3>2, <3>6, <1>p
+            <4>3. a - 1 = b - 1
+                BY <4>1, <4>2, <1>p DEF SimplePath, IsInjective
+            <4>. QED
+                BY <4>3, <3>2
+        <3>. QED
+            BY <3>2, <3>3, <3>4, <3>5, <3>6
+    <2>. QED
+        BY <2>1, <2>2 DEF SimplePath
+<1>5. q[Len(q)] = n /\ \A i \in 1..Len(q) : Op(q[i])
+    <2>1. Len(q) = Len(p) + 1 /\ Len(q) >= 2 /\ Len(q) \in 2..(Len(p)+1)
+        BY <1>2, <1>p
+    <2>2. q[Len(q)] = p[Len(q) - 1] /\ Len(q) - 1 = Len(p)
+        BY <1>2, <2>1, <1>p
+    <2>3. q[Len(q)] = n
+        BY <2>2, <1>p
+    <2>4. \A i \in 1..Len(q) : Op(q[i])
+        <3> SUFFICES ASSUME NEW i \in 1..Len(q) PROVE Op(q[i])
+            OBVIOUS
+        <3>1. i \in Nat /\ i >= 1 /\ i <= Len(p) + 1
+            BY <1>2, <1>p
+        <3>2. CASE i = 1
+            BY <3>2, <1>2
+        <3>3. CASE i >= 2
+            <4>1. q[i] = p[i-1] /\ i - 1 \in 1..Len(p)
+                BY <1>2, <3>1, <3>3, <1>p
+            <4>. QED
+                BY <4>1, <1>p
+        <3>. QED
+            BY <3>1, <3>2, <3>3
+    <2>. QED
+        BY <2>3, <2>4
+<1>. QED
+    BY <1>4, <1>5, <1>2 DEF OpenPath
+
+(******************************************************************************)
+(* A maximal open path to n exists whenever some open path to n does: a        *)
+(* longest open path (lengths are bounded by Cardinality(G.node)) has a root   *)
+(* with no Op-predecessor, since prepending one (DDG_PrependOpenPath) would    *)
+(* give a strictly longer open path.                                           *)
+(******************************************************************************)
+THEOREM DDG_MaximalOpenPathExists ==
+    ASSUME NEW G, IsDag(G), IsFiniteSet(G.node),
+           NEW n, NEW Op(_), OpenPath(G, n, Op) # {}
+    PROVE  MaximalOpenPath(G, n, Op) # {}
+<1>1. IsDirectedGraph(G) /\ Cardinality(G.node) \in Nat
+    BY FS_CardinalityType DEF IsDag
+<1> DEFINE OP == OpenPath(G, n, Op)
+<1> DEFINE Lens == {Len(p) : p \in OP}
+<1>2. \A q \in OP : /\ q \in SimplePath(G)
+                    /\ q \in Seq(G.node)
+                    /\ q[Len(q)] = n
+                    /\ (\A i \in 1..Len(q) : Op(q[i]))
+                    /\ Len(q) \in Nat
+                    /\ Len(q) >= 1
+                    /\ Len(q) <= Cardinality(G.node)
+                    /\ DOMAIN q = 1..Len(q)
+                    /\ IsInjective(q)
+    BY DG_SimplePathIsSeq, DG_SimplePathBound DEF OpenPath
+<1>3. /\ Lens # {}
+      /\ Lens \subseteq Int
+      /\ \A l \in Lens : l <= Cardinality(G.node)
+    BY <1>2
+<1>4. Max(Lens) \in Lens /\ \A l \in Lens : Max(Lens) >= l
+    BY <1>3, <1>1, MaxIntBounded
+<1>5. PICK p0 \in OP : \A q \in OP : Len(q) <= Len(p0)
+    BY <1>4
+<1>6. \A u \in Predecessor(G, p0[1]) : ~Op(u)
+    <2> SUFFICES ASSUME NEW u \in Predecessor(G, p0[1]), Op(u)
+                 PROVE  FALSE
+        OBVIOUS
+    <2>p. /\ p0 \in SimplePath(G) /\ p0 \in Seq(G.node) /\ p0[Len(p0)] = n
+          /\ (\A i \in 1..Len(p0) : Op(p0[i]))
+          /\ Len(p0) \in Nat /\ Len(p0) >= 1 /\ DOMAIN p0 = 1..Len(p0)
+          /\ IsInjective(p0)
+        BY <1>5, <1>2
+    <2>1. <<u, p0[1]>> \in G.edge /\ u \in G.node
+        BY DEF Predecessor
+    <2> DEFINE q == <<u>> \o p0
+    <2>2. /\ q \in Seq(G.node)
+          /\ Len(q) = Len(p0) + 1
+          /\ q[1] = u
+          /\ \A i \in 2..(Len(p0) + 1) : q[i] = p0[i-1]
+        <3>1. <<u>> \in Seq(G.node) /\ Len(<<u>>) = 1
+            BY <2>1
+        <3>2. /\ q \in Seq(G.node)
+              /\ Len(q) = 1 + Len(p0)
+              /\ \A i \in 1..(1 + Len(p0)) :
+                    q[i] = IF i <= 1 THEN <<u>>[i] ELSE p0[i-1]
+            BY <3>1, <2>p, ConcatProperties
+        <3>. QED
+            BY <3>2, <2>p
+    \* u is not a node of p0 (otherwise p0[1] reaches u and u -> p0[1] is a back edge)
+    <2>3. \A j \in 1..Len(p0) : p0[j] # u
+        <3> SUFFICES ASSUME NEW j \in 1..Len(p0), p0[j] = u
+                     PROVE  FALSE
+            OBVIOUS
+        <3> DEFINE pre == [i \in 1..j |-> p0[i]]
+        <3>1. j \in Nat /\ j >= 1 /\ j <= Len(p0)
+            BY <2>p
+        <3>2. /\ pre \in Seq(G.node)
+              /\ Len(pre) = j
+              /\ DOMAIN pre = 1..j
+              /\ \A i \in 1..j : pre[i] = p0[i]
+            <4>1. \A i \in 1..j : p0[i] \in G.node
+                BY <2>p, <3>1, ElementOfSeq
+            <4>2. pre \in Seq(G.node)
+                BY <4>1, <3>1, IsASeq, Isa
+            <4>3. DOMAIN pre = 1..j /\ \A i \in 1..j : pre[i] = p0[i]
+                OBVIOUS
+            <4>4. Len(pre) = j
+                BY <4>2, <4>3, <3>1, LenProperties
+            <4>. QED
+                BY <4>2, <4>3, <4>4
+        <3>3. pre \in SimplePath(G)
+            <4>1. pre # <<>> /\ Len(pre) >= 1
+                BY <3>2, <3>1
+            <4>2. \A i \in 1..(Len(pre) - 1) : <<pre[i], pre[i+1]>> \in G.edge
+                <5> SUFFICES ASSUME NEW i \in 1..(Len(pre) - 1)
+                             PROVE  <<pre[i], pre[i+1]>> \in G.edge
+                    OBVIOUS
+                <5>1. i \in 1..j /\ i + 1 \in 1..j
+                    BY <3>2, <3>1
+                <5>2. pre[i] = p0[i] /\ pre[i+1] = p0[i+1]
+                    BY <5>1, <3>2
+                <5>3. i \in 1..(Len(p0) - 1)
+                    BY <5>1, <3>1, <2>p
+                <5>. QED
+                    BY <5>2, <5>3, <2>p DEF SimplePath, Path
+            <4>3. pre \in Path(G)
+                BY <3>2, <4>1, <4>2 DEF Path
+            <4>4. IsInjective(pre)
+                <5> SUFFICES ASSUME NEW a \in DOMAIN pre, NEW b \in DOMAIN pre,
+                                    pre[a] = pre[b]
+                             PROVE  a = b
+                    BY DEF IsInjective
+                <5>1. DOMAIN pre = 1..j
+                    BY <3>2, LenProperties
+                <5>2. a \in 1..j /\ b \in 1..j /\ pre[a] = p0[a] /\ pre[b] = p0[b]
+                    BY <5>1, <3>2
+                <5>3. a \in 1..Len(p0) /\ b \in 1..Len(p0)
+                    BY <5>2, <3>1, <2>p
+                <5>. QED
+                    BY <5>2, <5>3, <2>p DEF SimplePath, IsInjective
+            <4>. QED
+                BY <4>3, <4>4 DEF SimplePath
+        <3>4. pre[1] = p0[1] /\ pre[Len(pre)] = u
+            BY <3>2, <3>1
+        <3>5. AreConnectedIn(G, p0[1], u)
+            BY <3>3, <3>4 DEF AreConnectedIn
+        <3>. QED
+            BY <3>5, <2>1, DG_DagNoBackEdge
+    <2>4. q \in SimplePath(G)
+        <3>1. q \in Path(G)
+            <4>1. q # <<>> /\ Len(q) >= 1
+                BY <2>2, <2>p
+            <4>2. \A i \in 1..(Len(q) - 1) : <<q[i], q[i+1]>> \in G.edge
+                <5> SUFFICES ASSUME NEW i \in 1..(Len(q) - 1)
+                             PROVE  <<q[i], q[i+1]>> \in G.edge
+                    OBVIOUS
+                <5>1. i \in Nat /\ i >= 1 /\ i <= Len(p0)
+                    BY <4>1, <2>2, <2>p
+                <5>2. CASE i = 1
+                    <6>1. q[1] = u /\ q[2] = p0[1]
+                        BY <2>2, <2>p
+                    <6>. QED
+                        BY <5>2, <6>1, <2>1
+                <5>3. CASE i >= 2
+                    <6>1. q[i] = p0[i-1] /\ q[i+1] = p0[i]
+                        BY <2>2, <5>1, <5>3, <2>p
+                    <6>2. i - 1 \in 1..(Len(p0) - 1)
+                        BY <5>1, <5>3, <2>p
+                    <6>. QED
+                        BY <6>1, <6>2, <2>p DEF SimplePath, Path
+                <5>. QED
+                    BY <5>1, <5>2, <5>3
+            <4>. QED
+                BY <2>2, <4>1, <4>2 DEF Path
+        <3>2. IsInjective(q)
+            <4> SUFFICES ASSUME NEW a \in DOMAIN q, NEW b \in DOMAIN q,
+                                q[a] = q[b]
+                         PROVE  a = b
+                BY DEF IsInjective
+            <4>1. DOMAIN q = 1..Len(q) /\ a \in 1..Len(q) /\ b \in 1..Len(q)
+                BY <2>2, LenProperties
+            <4>2. /\ a \in Nat /\ b \in Nat /\ a >= 1 /\ b >= 1
+                  /\ a <= Len(p0) + 1 /\ b <= Len(p0) + 1
+                BY <4>1, <2>2, <2>p
+            <4>3. CASE a = 1 /\ b = 1
+                BY <4>3
+            <4>4. CASE a = 1 /\ b >= 2
+                <5>1. q[a] = u /\ q[b] = p0[b-1] /\ b - 1 \in 1..Len(p0)
+                    BY <2>2, <4>2, <4>4, <2>p
+                <5>. QED
+                    BY <5>1, <2>3
+            <4>5. CASE b = 1 /\ a >= 2
+                <5>1. q[b] = u /\ q[a] = p0[a-1] /\ a - 1 \in 1..Len(p0)
+                    BY <2>2, <4>2, <4>5, <2>p
+                <5>. QED
+                    BY <5>1, <2>3
+            <4>6. CASE a >= 2 /\ b >= 2
+                <5>1. q[a] = p0[a-1] /\ q[b] = p0[b-1]
+                    BY <2>2, <4>2, <4>6
+                <5>2. a - 1 \in 1..Len(p0) /\ b - 1 \in 1..Len(p0)
+                    BY <4>2, <4>6, <2>p
+                <5>3. a - 1 = b - 1
+                    BY <5>1, <5>2, <2>p DEF SimplePath, IsInjective
+                <5>. QED
+                    BY <5>3, <4>2
+            <4>. QED
+                BY <4>2, <4>3, <4>4, <4>5, <4>6
+        <3>. QED
+            BY <3>1, <3>2 DEF SimplePath
+    <2>5. q[Len(q)] = n /\ \A i \in 1..Len(q) : Op(q[i])
+        <3>1. Len(q) = Len(p0) + 1 /\ Len(q) >= 2 /\ Len(q) \in 2..(Len(p0)+1)
+            BY <2>2, <2>p
+        <3>2. q[Len(q)] = p0[Len(q) - 1] /\ Len(q) - 1 = Len(p0)
+            BY <2>2, <3>1, <2>p
+        <3>3. q[Len(q)] = n
+            BY <3>2, <2>p
+        <3>4. \A i \in 1..Len(q) : Op(q[i])
+            <4> SUFFICES ASSUME NEW i \in 1..Len(q) PROVE Op(q[i])
+                OBVIOUS
+            <4>1. i \in Nat /\ i >= 1 /\ i <= Len(p0) + 1
+                BY <2>2, <2>p
+            <4>2. CASE i = 1
+                BY <4>2, <2>2
+            <4>3. CASE i >= 2
+                <5>1. q[i] = p0[i-1] /\ i - 1 \in 1..Len(p0)
+                    BY <2>2, <4>1, <4>3, <2>p
+                <5>. QED
+                    BY <5>1, <2>p
+            <4>. QED
+                BY <4>1, <4>2, <4>3
+        <3>. QED
+            BY <3>3, <3>4
+    <2>6. q \in OP /\ Len(q) = Len(p0) + 1
+        BY <2>4, <2>5, <2>2 DEF OpenPath
+    <2>7. Len(q) <= Len(p0)
+        BY <1>5, <2>6
+    <2>. QED
+        BY <2>6, <2>7, <2>p
+<1>. QED
+    BY <1>5, <1>6 DEF MaximalOpenPath
+
+(******************************************************************************)
+(* IsStrictSuffix in concrete terms: a strict suffix is strictly shorter and  *)
+(* aligns with the tail of the longer sequence. Derived from IsStrictPrefix on *)
+(* the reversed sequences (IsSuffix is IsPrefix of the reverses).             *)
+(******************************************************************************)
+LEMMA DDG_StrictSuffixChar ==
+    ASSUME NEW S, NEW s \in Seq(S), NEW t \in Seq(S), IsStrictSuffix(s, t)
+    PROVE  /\ Len(s) < Len(t)
+           /\ \A i \in 1..Len(s) : s[i] = t[(Len(t) - Len(s)) + i]
+<1>r. /\ Reverse(s) \in Seq(S) /\ Reverse(t) \in Seq(S)
+      /\ Len(Reverse(s)) = Len(s) /\ Len(Reverse(t)) = Len(t)
+      /\ Reverse(Reverse(s)) = s /\ Reverse(Reverse(t)) = t
+    BY ReverseProperties
+<1>n. Len(s) \in Nat /\ Len(t) \in Nat
+    BY LenProperties
+<1>1. IsPrefix(Reverse(s), Reverse(t)) /\ s # t
+    BY DEF IsStrictSuffix, IsSuffix
+<1>2. Reverse(s) # Reverse(t)
+    BY <1>1, <1>r, ReverseEqual
+<1>3. IsStrictPrefix(Reverse(s), Reverse(t))
+    BY <1>1, <1>2 DEF IsStrictPrefix
+<1>4. Len(Reverse(s)) < Len(Reverse(t))
+      /\ Reverse(s) = SubSeq(Reverse(t), 1, Len(Reverse(s)))
+    BY <1>3, <1>r, IsStrictPrefixProperties
+<1>5. Len(s) < Len(t)
+    BY <1>4, <1>r
+<1>6. \A i \in 1..Len(s) : s[i] = t[(Len(t) - Len(s)) + i]
+    <2> SUFFICES ASSUME NEW i \in 1..Len(s) PROVE s[i] = t[(Len(t) - Len(s)) + i]
+        OBVIOUS
+    <2> DEFINE ii == (Len(s) - i) + 1
+    <2>1. ii \in 1..Len(Reverse(s)) /\ ii \in 1..Len(s) /\ ii \in 1..Len(t)
+        BY <1>n, <1>r, <1>5
+    <2>2. Reverse(s)[ii] = Reverse(t)[ii]
+        BY <1>1, <1>r, <2>1, IsPrefixElts
+    <2>3. Reverse(s)[ii] = s[(Len(s) - ii) + 1]
+        BY <2>1, <1>r DEF Reverse
+    <2>4. Reverse(t)[ii] = t[(Len(t) - ii) + 1]
+        BY <2>1, <1>r DEF Reverse
+    <2>5. (Len(s) - ii) + 1 = i /\ (Len(t) - ii) + 1 = (Len(t) - Len(s)) + i
+        BY <1>n, <1>5
+    <2>. QED
+        BY <2>2, <2>3, <2>4, <2>5
+<1>. QED
+    BY <1>5, <1>6
+
+(******************************************************************************)
+(* On a DAG, the "root has no Op-predecessor" characterisation of             *)
+(* MaximalOpenPath coincides with the order-theoretic one: an open path is    *)
+(* maximal iff it is not a proper (strict) suffix of any other open path.     *)
+(******************************************************************************)
+THEOREM DDG_MaximalOpenPathSuffixEquiv ==
+    ASSUME NEW G, IsDag(G), NEW n, NEW Op(_)
+    PROVE  MaximalOpenPath(G, n, Op) =
+           {p \in OpenPath(G, n, Op) :
+                \A q \in OpenPath(G, n, Op) : ~ IsStrictSuffix(p, q)}
+<1>1. IsDirectedGraph(G)
+    BY DEF IsDag
+<1> DEFINE OP == OpenPath(G, n, Op)
+<1>. SUFFICES ASSUME NEW p \in OP
+              PROVE  (\A u \in Predecessor(G, p[1]) : ~Op(u))
+                     <=> (\A r \in OP : ~ IsStrictSuffix(p, r))
+    BY DEF MaximalOpenPath
+<1>p. /\ p \in SimplePath(G) /\ p \in Seq(G.node) /\ p[Len(p)] = n
+      /\ (\A i \in 1..Len(p) : Op(p[i]))
+      /\ Len(p) \in Nat /\ Len(p) >= 1
+    BY DG_SimplePathIsSeq DEF OpenPath
+\* (=>) pred-closed implies suffix-maximal
+<1>2. (\A u \in Predecessor(G, p[1]) : ~Op(u))
+      => (\A r \in OP : ~ IsStrictSuffix(p, r))
+    <2> SUFFICES ASSUME \A u \in Predecessor(G, p[1]) : ~Op(u),
+                        NEW r \in OP, IsStrictSuffix(p, r)
+                 PROVE  FALSE
+        OBVIOUS
+    <2>r. /\ r \in SimplePath(G) /\ r \in Seq(G.node)
+          /\ (\A i \in 1..Len(r) : Op(r[i]))
+          /\ Len(r) \in Nat /\ Len(r) >= 1
+          /\ \A i \in 1..(Len(r) - 1) : <<r[i], r[i+1]>> \in G.edge
+        BY DG_SimplePathIsSeq DEF OpenPath, SimplePath, Path
+    <2>1. Len(p) < Len(r)
+          /\ \A i \in 1..Len(p) : p[i] = r[(Len(r) - Len(p)) + i]
+        BY <1>p, <2>r, DDG_StrictSuffixChar
+    <2> DEFINE k == Len(r) - Len(p)
+    <2>2. k \in 1..(Len(r) - 1) /\ k + 1 \in 1..Len(r) /\ k \in 1..Len(r)
+        BY <2>1, <1>p, <2>r
+    <2>3. p[1] = r[k + 1]
+        BY <2>1, <1>p
+    <2>4. r[k] \in G.node /\ <<r[k], r[k+1]>> \in G.edge
+        BY <2>2, <2>r, ElementOfSeq
+    <2>5. r[k] \in Predecessor(G, p[1])
+        BY <2>3, <2>4 DEF Predecessor
+    <2>6. Op(r[k])
+        BY <2>2, <2>r
+    <2>. QED
+        BY <2>5, <2>6
+\* (<=) suffix-maximal implies pred-closed
+<1>3. (\A r \in OP : ~ IsStrictSuffix(p, r))
+      => (\A u \in Predecessor(G, p[1]) : ~Op(u))
+    <2> SUFFICES ASSUME \A r \in OP : ~ IsStrictSuffix(p, r),
+                        NEW u \in Predecessor(G, p[1]), Op(u)
+                 PROVE  FALSE
+        OBVIOUS
+    <2>1. (<<u>> \o p) \in OP /\ Len(<<u>> \o p) = Len(p) + 1
+        BY DDG_PrependOpenPath
+    <2>2. u \in G.node
+        BY DEF Predecessor
+    <2>3. /\ p \in Seq(G.node) /\ <<u>> \in Seq(G.node)
+          /\ Reverse(p) \in Seq(G.node) /\ Reverse(<<u>>) = <<u>>
+        BY <1>p, <2>2, ReverseProperties, ReverseSingleton
+    <2>4. IsStrictSuffix(p, <<u>> \o p)
+        <3>1. Reverse(<<u>> \o p) = Reverse(p) \o <<u>>
+            BY <2>3, ReverseConcat
+        <3>2. IsPrefix(Reverse(p), Reverse(p) \o <<u>>)
+            BY <2>3, IsPrefixConcat
+        <3>3. IsSuffix(p, <<u>> \o p)
+            BY <3>1, <3>2 DEF IsSuffix
+        <3>4. p # (<<u>> \o p)
+            BY <2>1, <1>p
+        <3>. QED
+            BY <3>3, <3>4 DEF IsStrictSuffix
+    <2>. QED
+        BY <2>1, <2>4
+<1>. QED
+    BY <1>2, <1>3
 
 THEOREM DDG_RetryUnionIsDag ==
     ASSUME NEW G, IsDag(G), NEW t \in G.node, NEW u, u \notin G.node

--- a/specs/DDGraphs.tla
+++ b/specs/DDGraphs.tla
@@ -93,6 +93,18 @@ AncestorSubGraph(G, n, Op(_)) ==
     IN [node |-> N, edge |-> G.edge \cap (N \X N)]
 
 (******************************************************************************)
+(* The set of maximal open paths ending at n in G under Op: open paths that   *)
+(* cannot be extended further upstream, characterised here by the property    *)
+(* that the root (first node) p[1] has no Op-satisfying predecessor in G.     *)
+(* Equivalently (on a DAG, see DDG_MaximalOpenPathSuffixEquiv) these are the  *)
+(* open paths that are not a proper suffix of any other open path -- the      *)
+(* order-theoretic maximal elements for the "is a suffix of" relation. The    *)
+(* root of such a path is the upstream frontier of the open subgraph of n.    *)
+(******************************************************************************)
+MaximalOpenPath(G, n, Op(_)) ==
+    {p \in OpenPath(G, n, Op) : \A u \in Predecessor(G, p[1]) : ~Op(u)}
+
+(******************************************************************************)
 (* The retry attachment of node t in G with fresh node u: the smallest        *)
 (* graph H such that GraphUnion(G, H) extends G with u placed in parallel to  *)
 (* t -- u has the same predecessors and the same successors as t in G, and    *)

--- a/specs/GraphProcessing1.tla
+++ b/specs/GraphProcessing1.tla
@@ -388,7 +388,7 @@ CommittedObjectsEventualFinalization ==
  * LIVENESS
  * This specification refines the TaskProcessing specification.
  *)
-TP1 == INSTANCE TaskProcessing1
+TP1 == INSTANCE TaskProcessing1Theorems
 RefineTaskProcessing1 ==
     TP1!Spec
 

--- a/specs/GraphProcessing1_proofs.tla
+++ b/specs/GraphProcessing1_proofs.tla
@@ -2,8 +2,14 @@
 EXTENDS GraphProcessing1, DDGraphTheorems, FiniteSetTheorems, NaturalsInduction,
         SequenceTheorems, TLAPS
 
-USE DEF OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_FINALIZED, TASK_UNKNOWN,
-TASK_REGISTERED, TASK_STAGED, TASK_ASSIGNED, TASK_PROCESSED, TASK_FINALIZED
+USE GP1Assumptions DEF OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_FINALIZED,
+TASK_UNKNOWN, TASK_REGISTERED, TASK_STAGED, TASK_ASSIGNED, TASK_PROCESSED,
+TASK_FINALIZED
+
+LEMMA SameAssumptions == GP1Assumptions => TP1!TP1Assumptions
+BY DEF IsDenumerableSet, ExistsBijection, Bijection, Injection, Surjection,
+IsInjective, TP1!IsDenumerableSet, TP1!ExistsBijection, TP1!Bijection,
+TP1!Injection, TP1!Surjection, TP1!IsInjective
 
 (*****************************************************************************)
 (* TYPE INVARIANT                                                            *)
@@ -1213,44 +1219,11 @@ LEMMA LemStableTaskSuccessors ==
     StageTasks, DiscardTasks, AssignTasks, ReleaseTasks, ProcessTasks,
     FinalizeTasks, Terminating
 
-(*****************************************************************************)
-(* Boxed monotonicity for the successor-coverage predicate over a growing    *)
-(* set.  BSE_R(t, S, U) holds when S is t's successor set and every object   *)
-(* in U still has a non-t, non-finalized predecessor (BSE_Q).  Extending U   *)
-(* by one object x preserves BSE_R as long as BSE_Q(t, x) holds.             *)
-(*                                                                           *)
-(* This is extracted as a lemma (rather than proved inline) because lifting  *)
-(* the state validity R(T) /\ Q(x) => R(T \cup {x}) through <>[] requires the *)
-(* *boxed* implication [](...), and LS4 cannot necessitate that validity     *)
-(* while the induction hypothesis (which mentions R/Q under <>[]) is in       *)
-(* scope.  In this lemma's clean context the necessitation succeeds.  The     *)
-(* operators mirror the FinalizeTasks WF1 definitions of Q, Succ and R so the *)
-(* use site discharges by definitional matching.                             *)
-(*****************************************************************************)
-BSE_Q(t, o)    == o \in RegisteredObject
-                    => \E u \in (Predecessor(deps, o) \ {t}) : u \notin FinalizedTask
-BSE_R(t, S, U) == S = UNION {Successor(deps, u) : u \in {t}}
-                    /\ \A o \in U : BSE_Q(t, o)
-
-LEMMA LemBoxSetExtend ==
-    ASSUME NEW t, NEW S, NEW T, NEW x
-    PROVE  <>[](BSE_R(t, S, T) /\ BSE_Q(t, x)) => <>[]BSE_R(t, S, T \cup {x})
-<1>1. BSE_R(t, S, T) /\ BSE_Q(t, x) => BSE_R(t, S, T \cup {x})
-    BY DEF BSE_R
-<1>. HIDE DEF BSE_Q, BSE_R
-\* <1>1 is a state-level validity (no flexible hypotheses), hence necessitable.
-<1>2. [](BSE_R(t, S, T) /\ BSE_Q(t, x) => BSE_R(t, S, T \cup {x}))
-    BY ONLY <1>1, PTL
-\* Temporal monotonicity from the boxed implication.
-<1>. QED
-    BY ONLY <1>2, PTL
-
-THEOREM GP1_RefineTaskProcessing1 == Spec => RefineTaskProcessing1
+LEMMA LemRefineTaskProcessing1Next ==
+    GraphSafetyInv /\ [Next]_vars => [TP1!Next]_(TP1!vars)
 <1>. USE DEF TP1!TASK_UNKNOWN, TP1!TASK_REGISTERED, TP1!TASK_STAGED, TP1!TASK_ASSIGNED,
      TP1!TASK_PROCESSED, TP1!TASK_FINALIZED
-<1>1. Init => TP1!Init
-    BY DEF Init, TP1!Init
-<1>2. GraphSafetyInv /\ [Next]_vars => [TP1!Next]_(TP1!vars)
+<1>1. GraphSafetyInv /\ [Next]_vars => [TP1!Next]_(TP1!vars)
     <2>. SUFFICES ASSUME TypeOk
                 PROVE [Next]_vars => [TP1!Next]_(TP1!vars)
         BY DEF GraphSafetyInv
@@ -1306,7 +1279,14 @@ THEOREM GP1_RefineTaskProcessing1 == Spec => RefineTaskProcessing1
     <2>. QED
         BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8, <2>9, <2>10, <2>11, <2>12
         DEF Next, TP1!Next
-<1>3. [][Next]_vars /\ []GraphSafetyInv /\ Fairness => TP1!Fairness
+<1>. QED
+    BY <1>1
+
+LEMMA LemRefineTaskProcessing1Fairness ==
+    [][Next]_vars /\ []GraphSafetyInv /\ Fairness => TP1!Fairness
+<1>. USE DEF TP1!TASK_UNKNOWN, TP1!TASK_REGISTERED, TP1!TASK_STAGED, TP1!TASK_ASSIGNED,
+     TP1!TASK_PROCESSED, TP1!TASK_FINALIZED
+<1>1. [][Next]_vars /\ []GraphSafetyInv /\ Fairness => TP1!Fairness
     <2>. SUFFICES ASSUME NEW t \in Task
                   PROVE /\ SF_vars(ProcessTasks({t}))
                            => SF_TP1!vars(TP1!ProcessTasks({t}))
@@ -1389,7 +1369,7 @@ THEOREM GP1_RefineTaskProcessing1 == Spec => RefineTaskProcessing1
                             <=> WF_vars(FinalizeObjects({o}))
                     BY PTL
                 <5>. QED
-                    BY <5>1, <5>2
+                    BY Isa, <5>1, <5>2
             <4>4. /\ []GraphSafetyInv
                   /\ [][Next]_vars
                   /\ [](\A o \in Object : WF_vars(FinalizeObjects({o})))
@@ -1443,7 +1423,13 @@ THEOREM GP1_RefineTaskProcessing1 == Spec => RefineTaskProcessing1
                                 BY <8>1, LemStableTaskSuccessors
                         <7>. QED
                             BY <7>2, <7>3, PTL
-                    <6>2. ASSUME NEW T \in SUBSET S, IsFiniteSet(T), I(T), NEW x \in S \ T
+                    <6>2. ASSUME NEW T \in SUBSET S, NEW x \in S \ T
+                           PROVE <>[](R(T) /\ Q(x)) => <>[]R(T \cup {x})
+                        <7>1. R(T) /\ Q(x) => R(T \cup {x})
+                                OBVIOUS
+                        <7>. QED
+                            BY <7>1, PTL
+                    <6>3. ASSUME NEW T \in SUBSET S, IsFiniteSet(T), I(T), NEW x \in S \ T
                           PROVE  I(T \cup {x})
                         <8>1. L(T \cup {x}) => K(x)
                             <9>. HIDE DEF K
@@ -1453,31 +1439,15 @@ THEOREM GP1_RefineTaskProcessing1 == Spec => RefineTaskProcessing1
                             OBVIOUS
                         <8>3. (A(S) => <>[]R(T)) /\ K(x) => A(S) => (<>[](R(T) /\ Q(x)))
                             BY PTL
-                        \* Temporal monotonicity over the growing set.  Lifting the
-                        \* state validity R(T) /\ Q(x) => R(T \cup {x}) through <>[]
-                        \* needs the *boxed* implication, which LS4 cannot necessitate
-                        \* while the induction hypothesis I(T) (mentioning R/Q under
-                        \* <>[]) is in scope.  LemBoxSetExtend performs the lift in a
-                        \* clean context; the DEF expansions match its BSE_R/BSE_Q to
-                        \* the local R/Q/Succ.
                         <8>5. <>[](R(T) /\ Q(x)) => <>[]R(T \cup {x})
-                            BY LemBoxSetExtend DEF R, Q, Succ, BSE_R, BSE_Q
-                        \* Hide the set-shaped definitions (keeping I visible) so the
-                        \* closing argument is a purely propositional/temporal
-                        \* combination over the atoms L(_), A(S), <>[]R(_) and
-                        \* <>[](R(T) /\ Q(x)); leaving R/C/K/L visible re-expands the \A
-                        \* over T \cup {x} and breaks coalescing.  Citing <6>2 brings the
-                        \* induction hypothesis I(T) into PTL scope: a temporal ASSUME
-                        \* hypothesis of an enclosing step is otherwise dropped from the
-                        \* coalesced context.
-                        <8>. HIDE DEF Q, Succ, A, R, C, K, L
+                            BY <6>2
                         <8>. QED
-                            BY <6>2, <8>1, <8>2, <8>3, <8>5, PTL
+                            BY <6>3, <8>1, <8>2, <8>3, <8>5, PTL
                     <6>. HIDE DEF I
-                    <6>3. I(S)
-                        BY <6>1, <6>2, FS_Induction, IsaM("blast")
+                    <6>4. I(S)
+                        BY <6>1, <6>3, FS_Induction, IsaM("blast")
                     <6>. QED
-                        BY <6>3 DEF I
+                        BY <6>4 DEF I
                 <5>0b. [](\A o \in Object : WF_vars(FinalizeObjects({o})))
                        => \A o \in Object : WF_vars(FinalizeObjects({o}))
                     <6>1. [](\A o \in Object : WF_vars(FinalizeObjects({o})))
@@ -1491,7 +1461,7 @@ THEOREM GP1_RefineTaskProcessing1 == Spec => RefineTaskProcessing1
                                     /\ WF_vars(FinalizeObjects({o}))
                                     /\ [](t \in ProcessedTask)
                                     => [](A(S) => <>[]C(S, o))
-                    BY <5>0a, <5>0b
+                    BY Isa, <5>0a, <5>0b
                 <5>1. A(S) => \/ A(S) /\ o \in FinalizedObject
                               \/ A(S) /\ ~ o \in FinalizedObject
                     OBVIOUS
@@ -1563,7 +1533,7 @@ THEOREM GP1_RefineTaskProcessing1 == Spec => RefineTaskProcessing1
                     <6>. QED
                         BY <6>1, <6>2, <6>3
                 <5>6. S = Succ /\ o \in FinalizedObject => C(S, o)
-    \*                 BY DEF RegisteredObject, FinalizedObject
+                    BY DEF RegisteredObject, FinalizedObject
                 <5>. QED
                     BY <5>1, <5>2, <5>3, <5>4, <5>5, <5>6, PTL
             <4>5. [](\A S \in SUBSET Object: A(S) => <>[]B(S))
@@ -1585,10 +1555,772 @@ THEOREM GP1_RefineTaskProcessing1 == Spec => RefineTaskProcessing1
     <2>. QED
         BY <2>1, <2>2, Isa
 <1>. QED
+    BY <1>1
+
+THEOREM GP1_RefineTaskProcessing1 == Spec => RefineTaskProcessing1
+<1>. USE DEF TP1!TASK_UNKNOWN, TP1!TASK_REGISTERED, TP1!TASK_STAGED, TP1!TASK_ASSIGNED,
+     TP1!TASK_PROCESSED, TP1!TASK_FINALIZED
+<1>1. Init => TP1!Init
+    BY DEF Init, TP1!Init
+<1>2. GraphSafetyInv /\ [Next]_vars => [TP1!Next]_(TP1!vars)
+    BY LemRefineTaskProcessing1Next
+<1>3. [][Next]_vars /\ []GraphSafetyInv /\ Fairness => TP1!Fairness
+    BY LemRefineTaskProcessing1Fairness
+<1>. QED
     BY <1>1, <1>2, <1>3, GP1_GraphSafetyInv, PTL DEF Spec, TP1!Spec, RefineTaskProcessing1
 
+(**
+ * IsOpenNode evaluated in the successor state. Module-level so that tlapm can
+ * instantiate the second-order Op(_) parameter of the DDGraphTheorems lemmas
+ * with it (a proof-local DEFINE does not match), letting the whole DDG library
+ * be applied to the next-state graph deps'.
+ *)
+OpPrimed(m) == IsOpenNode(m)'
+
+(**
+ * Transition relation of taskState[t] under any system step: a task either
+ * keeps its state or follows the registered -> staged/processed ->
+ * assigned/processed -> finalized lifecycle.
+ *)
+LEMMA LemTaskTransitions ==
+    ASSUME NEW t \in Task
+    PROVE [Next]_vars =>
+            \/ taskState'[t] = taskState[t]
+            \/ taskState[t] = TASK_UNKNOWN /\ taskState'[t] = TASK_REGISTERED
+            \/ taskState[t] = TASK_REGISTERED /\ taskState'[t] \in {TASK_STAGED, TASK_PROCESSED}
+            \/ taskState[t] = TASK_STAGED /\ taskState'[t] \in {TASK_ASSIGNED, TASK_PROCESSED}
+            \/ taskState[t] = TASK_ASSIGNED /\ taskState'[t] \in {TASK_STAGED, TASK_PROCESSED}
+            \/ taskState[t] = TASK_PROCESSED /\ taskState'[t] = TASK_FINALIZED
+<1>. DEFINE D == \/ taskState'[t] = taskState[t]
+                 \/ taskState[t] = TASK_UNKNOWN /\ taskState'[t] = TASK_REGISTERED
+                 \/ taskState[t] = TASK_REGISTERED /\ taskState'[t] \in {TASK_STAGED, TASK_PROCESSED}
+                 \/ taskState[t] = TASK_STAGED /\ taskState'[t] \in {TASK_ASSIGNED, TASK_PROCESSED}
+                 \/ taskState[t] = TASK_ASSIGNED /\ taskState'[t] \in {TASK_STAGED, TASK_PROCESSED}
+                 \/ taskState[t] = TASK_PROCESSED /\ taskState'[t] = TASK_FINALIZED
+<1>. SUFFICES ASSUME [Next]_vars PROVE D
+    OBVIOUS
+<1>1. ASSUME NEW G \in DirectedGraphOf(Task \union Object), RegisterGraph(G)
+      PROVE D
+    BY <1>1 DEF RegisterGraph, UnknownTask, TASK_UNKNOWN, TASK_REGISTERED
+<1>2. ASSUME NEW O \in SUBSET Object, TargetObjects(O) \/ UntargetObjects(O) \/ FinalizeObjects(O)
+      PROVE D
+    BY <1>2 DEF TargetObjects, UntargetObjects, FinalizeObjects
+<1>3. ASSUME NEW T \in SUBSET Task, StageTasks(T)
+      PROVE D
+    BY <1>3 DEF StageTasks, RegisteredTask, TASK_REGISTERED, TASK_STAGED
+<1>4. ASSUME NEW T \in SUBSET Task, DiscardTasks(T)
+      PROVE D
+    BY <1>4 DEF DiscardTasks, RegisteredTask, StagedTask,
+       TASK_REGISTERED, TASK_STAGED, TASK_PROCESSED
+<1>5. ASSUME NEW T \in SUBSET Task, AssignTasks(T)
+      PROVE D
+    BY <1>5 DEF AssignTasks, StagedTask, TASK_STAGED, TASK_ASSIGNED
+<1>6. ASSUME NEW T \in SUBSET Task, ReleaseTasks(T)
+      PROVE D
+    BY <1>6 DEF ReleaseTasks, AssignedTask, TASK_ASSIGNED, TASK_STAGED
+<1>7. ASSUME NEW T \in SUBSET Task, ProcessTasks(T)
+      PROVE D
+    BY <1>7 DEF ProcessTasks, AssignedTask, TASK_ASSIGNED, TASK_PROCESSED
+<1>8. ASSUME NEW T \in SUBSET Task, FinalizeTasks(T)
+      PROVE D
+    BY <1>8 DEF FinalizeTasks, ProcessedTask, TASK_PROCESSED, TASK_FINALIZED
+<1>9. ASSUME Terminating \/ UNCHANGED vars
+      PROVE D
+    BY <1>9 DEF Terminating, vars
+<1>. QED
+    BY <1>1, <1>2, <1>3, <1>4, <1>5, <1>6, <1>7, <1>8, <1>9 DEF Next, vars
+
+(**
+ * Transition relation of objectState[x] under any system step: an object
+ * either keeps its state or follows unknown -> registered -> finalized.
+ *)
+LEMMA LemObjectTransitions ==
+    ASSUME NEW x \in Object
+    PROVE [Next]_vars =>
+            \/ objectState'[x] = objectState[x]
+            \/ objectState[x] = OBJECT_UNKNOWN /\ objectState'[x] = OBJECT_REGISTERED
+            \/ objectState[x] = OBJECT_REGISTERED /\ objectState'[x] = OBJECT_FINALIZED
+<1>. DEFINE D == \/ objectState'[x] = objectState[x]
+                 \/ objectState[x] = OBJECT_UNKNOWN /\ objectState'[x] = OBJECT_REGISTERED
+                 \/ objectState[x] = OBJECT_REGISTERED /\ objectState'[x] = OBJECT_FINALIZED
+<1>. SUFFICES ASSUME [Next]_vars PROVE D
+    OBVIOUS
+<1>1. ASSUME NEW G \in DirectedGraphOf(Task \union Object), RegisterGraph(G)
+      PROVE D
+    BY <1>1 DEF RegisterGraph, UnknownObject
+<1>2. ASSUME NEW O \in SUBSET Object, FinalizeObjects(O)
+      PROVE D
+    BY <1>2 DEF FinalizeObjects, RegisteredObject
+<1>3. ASSUME NEW O \in SUBSET Object, TargetObjects(O) \/ UntargetObjects(O)
+      PROVE D
+    BY <1>3 DEF TargetObjects, UntargetObjects
+<1>4. ASSUME NEW T \in SUBSET Task,
+             \/ StageTasks(T) \/ DiscardTasks(T) \/ AssignTasks(T)
+             \/ ReleaseTasks(T) \/ ProcessTasks(T) \/ FinalizeTasks(T)
+      PROVE D
+    BY <1>4 DEF StageTasks, DiscardTasks, AssignTasks, ReleaseTasks,
+       ProcessTasks, FinalizeTasks
+<1>5. ASSUME Terminating \/ UNCHANGED vars
+      PROVE D
+    BY <1>5 DEF Terminating, vars
+<1>. QED
+    BY <1>1, <1>2, <1>3, <1>4, <1>5 DEF Next, vars
+
+(**
+ * STABILITY OF MAXIMAL-OPEN-PATH ROOTS. While r stays upstream of o on an
+ * open path, being the root of a maximal open path to o is preserved by every
+ * system step, provided the open ancestor set S of o never gains a node.
+ * Indeed the only threat is RegisterGraph attaching a new producing task
+ * above r: that task is freshly registered (hence open) and, r being an open
+ * ancestor of o, it would become a new open ancestor of o -- enlarging S,
+ * which [S' \subseteq S]_S forbids. All other steps leave the predecessors of
+ * r untouched, and closed (finalized) predecessors stay closed forever.
+ *)
+LEMMA LemMRootStable ==
+    ASSUME NEW o \in Object, NEW r \in Object \union Task
+    PROVE LET S == AncestorSubGraph(deps, o, IsOpenNode).node
+          IN /\ GraphSafetyInv /\ GraphSafetyInv'
+             /\ [Next]_vars /\ [S' \subseteq S]_S
+             /\ \E p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r
+             /\ IsTaskUpstreamOnOpenPathToTarget(r, o)'
+             => (\E p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r)'
+<1>. DEFINE S == AncestorSubGraph(deps, o, IsOpenNode).node
+<1>. SUFFICES ASSUME GraphSafetyInv, GraphSafetyInv',
+                     [Next]_vars, [S' \subseteq S]_S,
+                     \E p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r,
+                     IsTaskUpstreamOnOpenPathToTarget(r, o)'
+              PROVE  (\E p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r)'
+    BY Zenon
+<1>1. IsDirectedGraph(deps) /\ IsDag(deps)
+    BY Zenon DEF GraphSafetyInv, DependencyGraphCompliant, IsDDGraph, IsDag
+<1>2. IsDirectedGraph(deps') /\ IsDag(deps')
+    BY Zenon DEF GraphSafetyInv, DependencyGraphCompliant, IsDDGraph, IsDag
+<1>3. PICK p0 \in MaximalOpenPath(deps, o, IsOpenNode) : p0[1] = r
+    BY Zenon
+<1>4. \A u \in Predecessor(deps, r) : ~IsOpenNode(u)
+    BY Zenon, <1>3 DEF MaximalOpenPath
+<1>5. r \in deps.node
+    <2>1. p0 \in SimplePath(deps)
+        BY Zenon, <1>3 DEF MaximalOpenPath, OpenPath
+    <2>2. p0 \in Seq(deps.node) /\ Len(p0) >= 1 /\ Len(p0) \in Nat
+        BY Zenon, <2>1, DG_SimplePathIsSeq
+    <2>3. 1 \in 1..Len(p0)
+        BY Isa, <2>2
+    <2>. QED
+        BY Zenon, <1>3, <2>2, <2>3, ElementOfSeq
+(* The open path from r to o at the next state, recast over deps' and the
+ * next-state openness predicate OpPrimed so that the DDGraphTheorems lemmas
+ * apply to it. *)
+<1>6. PICK q : q \in OpenPath(deps, o, IsOpenNode)' /\ q[1] = r
+    BY Zenon DEF IsTaskUpstreamOnOpenPathToTarget
+<1>7. q \in OpenPath(deps', o, OpPrimed)
+    BY Zenon, <1>6 DEF OpPrimed, OpenPath
+(* Closed predecessors of r stay closed under every step. *)
+<1>8. \A u \in Predecessor(deps, r) : ~OpPrimed(u)
+    <2>. SUFFICES ASSUME NEW u \in Predecessor(deps, r) PROVE ~OpPrimed(u)
+        BY Zenon
+    <2>1. u \in Task \union Object
+        BY Zenon DEF Predecessor, GraphSafetyInv, TypeOk, DirectedGraphOf
+    <2>2. u \in FinalizedTask \/ u \in FinalizedObject
+        BY Zenon, <1>4 DEF IsOpenNode
+    <2>3. u \in FinalizedTask => u \in FinalizedTask'
+        <3>. SUFFICES ASSUME u \in FinalizedTask PROVE u \in FinalizedTask'
+            BY Zenon
+        <3>1. u \in Task /\ taskState[u] = TASK_FINALIZED
+            BY Zenon DEF FinalizedTask
+        <3>2. taskState'[u] = TASK_FINALIZED
+            BY Zenon, <3>1, LemTaskTransitions DEF TASK_UNKNOWN, TASK_REGISTERED,
+               TASK_STAGED, TASK_ASSIGNED
+        <3>. QED
+            BY Zenon, <3>1, <3>2 DEF FinalizedTask
+    <2>4. u \in FinalizedObject => u \in FinalizedObject'
+        <3>. SUFFICES ASSUME u \in FinalizedObject PROVE u \in FinalizedObject'
+            BY Zenon
+        <3>1. u \in Object /\ objectState[u] = OBJECT_FINALIZED
+            BY Zenon DEF FinalizedObject
+        <3>2. objectState'[u] = OBJECT_FINALIZED
+            BY Zenon, <3>1, LemObjectTransitions DEF OBJECT_UNKNOWN, OBJECT_REGISTERED
+        <3>. QED
+            BY Zenon, <3>1, <3>2 DEF FinalizedObject
+    <2>. QED
+        BY Zenon, <2>2, <2>3, <2>4 DEF OpPrimed, IsOpenNode
+(* No step adds a predecessor to r: only RegisterGraph could, and the added
+ * parent -- a fresh, hence open, task -- would join the open ancestor set of
+ * o, growing S against [S' \subseteq S]_S. *)
+<1>9. Predecessor(deps', r) \subseteq Predecessor(deps, r)
+    <2>1. deps' = deps \/ \E G \in DirectedGraphOf(Task \union Object) : RegisterGraph(G)
+        BY Zenon DEF Next, vars, TargetObjects, UntargetObjects, FinalizeObjects,
+           StageTasks, DiscardTasks, AssignTasks, ReleaseTasks,
+           ProcessTasks, FinalizeTasks, Terminating
+    <2>2. CASE deps' = deps
+        BY Zenon, <2>2 DEF Predecessor
+    <2>3. CASE \E G \in DirectedGraphOf(Task \union Object) : RegisterGraph(G)
+        <3>. SUFFICES ASSUME NEW u, u \in Predecessor(deps', r),
+                             u \notin Predecessor(deps, r)
+                      PROVE  FALSE
+            BY Zenon DEF Predecessor
+        <3>1. PICK G \in DirectedGraphOf(Task \union Object) : RegisterGraph(G)
+            BY Zenon, <2>3
+        <3>2. deps' = GraphUnion(deps, G)
+            BY Zenon, <3>1 DEF RegisterGraph
+        <3>3. <<u, r>> \in deps'.edge
+            BY Zenon DEF Predecessor
+        <3>4. <<u, r>> \notin deps.edge
+            BY Zenon, <1>1 DEF Predecessor, IsDirectedGraph
+        <3>5. <<u, r>> \in G.edge /\ u \in G.node /\ r \in G.node
+            <4>1. IsDirectedGraph(G)
+                BY Zenon DEF DirectedGraphOf
+            <4>. QED
+                BY Zenon, <3>2, <3>3, <3>4, <4>1 DEF GraphUnion, IsDirectedGraph
+        <3>6. r \notin Task
+            <4>. SUFFICES ASSUME r \in Task PROVE FALSE
+                BY Zenon
+            <4>1. r \in UnknownTask
+                BY Zenon, <3>1, <3>5 DEF RegisterGraph
+            <4>. QED
+                BY Zenon, <1>5, <4>1 DEF GraphSafetyInv, GraphStateIntegrity
+        <3>7. r \in Object
+            BY Zenon, <3>6
+        <3>8. u \in Task
+            <4>1. IsBipartiteWithPartitions(deps', Task, Object)
+                BY Zenon DEF GraphSafetyInv, DependencyGraphCompliant, IsDDGraph
+            <4>. QED
+                BY Zenon, <3>3, <3>7, <4>1, GP1Assumptions DEF IsBipartiteWithPartitions
+        <3>9. u \in UnknownTask /\ u \notin deps.node
+            <4>1. u \in UnknownTask
+                BY Zenon, <3>1, <3>5, <3>8 DEF RegisterGraph
+            <4>. QED
+                BY Zenon, <3>8, <4>1 DEF GraphSafetyInv, GraphStateIntegrity
+        <3>10. OpPrimed(u)
+            <4>1. taskState'[u] = TASK_REGISTERED
+                BY Zenon, <3>1, <3>5, <3>8 DEF RegisterGraph
+            <4>. QED
+                BY Zenon, <3>8, <4>1, GP1Assumptions
+                   DEF OpPrimed, IsOpenNode, FinalizedTask, FinalizedObject, TASK_REGISTERED
+        <3>11. r \in AncestorSubGraph(deps', o, OpPrimed).node
+            <4>1. q \in OpenPath(AncestorSubGraph(deps', o, OpPrimed), o, OpPrimed)
+                BY Zenon, <1>2, <1>7, DDG_OpenPathInAncestorSubGraph
+            <4>2. q \in SimplePath(AncestorSubGraph(deps', o, OpPrimed))
+                BY Zenon, <4>1 DEF OpenPath
+            <4>3. /\ q \in Seq(AncestorSubGraph(deps', o, OpPrimed).node)
+                  /\ Len(q) >= 1 /\ Len(q) \in Nat
+                BY Zenon, <4>2, DG_SimplePathIsSeq
+            <4>4. 1 \in 1..Len(q)
+                BY Isa, <4>3
+            <4>. QED
+                BY Zenon, <1>6, <4>3, <4>4, ElementOfSeq
+        <3>12. u \in AncestorSubGraph(deps', o, OpPrimed).node
+            <4>1. \A m \in AncestorSubGraph(deps', o, OpPrimed).node :
+                    \A x \in Predecessor(deps', m) \ AncestorSubGraph(deps', o, OpPrimed).node :
+                        ~OpPrimed(x)
+                BY ONLY <1>2, DDG_AncestorSubGraphIsMaximal, Isa
+            <4>2. u \in Predecessor(deps', r) \ AncestorSubGraph(deps', o, OpPrimed).node
+                  => ~OpPrimed(u)
+                BY Zenon, <3>11, <4>1
+            <4>. QED
+                BY Zenon, <3>10, <4>2
+        <3>13. u \in S
+            <4>1. (AncestorSubGraph(deps, o, IsOpenNode).node)'
+                  = AncestorSubGraph(deps', o, OpPrimed).node
+                BY DEF OpPrimed, AncestorSubGraph
+            <4>2. S' \subseteq S
+                BY Zenon
+            <4>. QED
+                BY Zenon, <3>12, <4>1, <4>2
+        <3>14. u \in deps.node
+            <4>1. S \subseteq deps.node
+                BY Zenon, <1>1, DDG_AncestorSubGraphBasic DEF DirectedSubgraph
+            <4>. QED
+                BY Zenon, <3>13, <4>1
+        <3>. QED
+            BY Zenon, <3>9, <3>14
+    <2>. QED
+        BY Zenon, <2>1, <2>2, <2>3
+(* Assemble: the open path from r at the next state is maximal there, since
+ * all predecessors of r at the next state are closed. *)
+<1>10. q \in MaximalOpenPath(deps', o, OpPrimed)
+    BY Zenon, <1>6, <1>7, <1>8, <1>9 DEF MaximalOpenPath
+<1>11. q \in MaximalOpenPath(deps, o, IsOpenNode)'
+    BY Zenon, <1>10 DEF OpPrimed, MaximalOpenPath, OpenPath
+<1>. QED
+    BY Zenon, <1>6, <1>11
+
+LEMMA LemRootProgress ==
+    ASSUME NEW o \in Object, NEW r \in Object \union Task, NEW n \in Nat
+    PROVE LET S == AncestorSubGraph(deps, o, IsOpenNode).node
+              C == Cardinality(S)
+              IsMRoot(o, r) == \E p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r
+          IN /\ []GraphSafetyInv /\ [][Next]_vars /\ []Fairness
+             /\ [](o \in objectTargets /\ o \in RegisteredObject)
+             /\ [][S' \subseteq S]_S
+             => C = n + 1 /\ IsMRoot(o, r) ~> C < n + 1
+<1>. USE DEF TP1!TASK_UNKNOWN, TP1!TASK_REGISTERED, TP1!TASK_STAGED, TP1!TASK_ASSIGNED,
+     TP1!TASK_PROCESSED, TP1!TASK_FINALIZED
+<1>. DEFINE S == AncestorSubGraph(deps, o, IsOpenNode).node
+            C == Cardinality(S)
+            IsMRoot(o, r) == \E p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r
+            J == C <= n + 1 /\ (C = n + 1 => r \in S)
+<1>1. o \in objectTargets /\ IsMRoot(o, r) => IsTaskUpstreamOnOpenPathToTarget(r, o)
+    BY DEF IsTaskUpstreamOnOpenPathToTarget, MaximalOpenPath, OpenPath
+<1>2. GraphSafetyInv /\ IsMRoot(o, r) => r \in S
+    <2>. SUFFICES ASSUME GraphSafetyInv, IsMRoot(o, r) PROVE r \in S
+        OBVIOUS
+    <2>1. PICK p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r
+        OBVIOUS
+    <2>2. IsDirectedGraph(deps)
+        BY DEF GraphSafetyInv, DependencyGraphCompliant, IsDDGraph, IsDag
+    <2>3. p \in OpenPath(deps, o, IsOpenNode)
+        BY <2>1 DEF MaximalOpenPath
+    <2>4. p \in OpenPath(AncestorSubGraph(deps, o, IsOpenNode), o, IsOpenNode)
+        BY Zenon, <2>2, <2>3, DDG_OpenPathInAncestorSubGraph
+    <2>5. p \in SimplePath(AncestorSubGraph(deps, o, IsOpenNode))
+        BY <2>4 DEF OpenPath
+    <2>. QED
+        BY <2>1, <2>5, DG_SimplePathIsSeq, ElementOfSeq
+<1>3. GraphSafetyInv => IsFiniteSet(S)
+    <2>. SUFFICES ASSUME GraphSafetyInv
+                  PROVE IsFiniteSet(S)
+        OBVIOUS
+    <2>1. IsDirectedGraph(deps)
+        BY DEF GraphSafetyInv, DependencyGraphCompliant, IsDDGraph, IsDag
+    <2>2. S \subseteq deps.node
+        BY Zenon, <2>1, DDG_AncestorSubGraphBasic DEF DirectedSubgraph
+    <2>3. IsFiniteSet(deps.node)
+        BY DEF GraphSafetyInv, DependencyGraphFinite
+    <2>. QED
+        BY <2>2, <2>3, FS_Subset
+<1>4. GraphSafetyInv /\ C = n + 1 /\ IsMRoot(o, r) => J
+    BY <1>2, <1>3
+<1>5. GraphSafetyInv /\ J /\ [S' \subseteq S]_S => J'
+    <2>. SUFFICES ASSUME GraphSafetyInv, J, [S' \subseteq S]_S
+                  PROVE  /\ C' <= n + 1
+                         /\ (C' = n + 1 => r \in S')
+        BY Zenon
+    <2>0. C \in Nat /\ C' \in Nat
+        BY Zenon, <1>3, FS_CardinalityType, FS_Subset
+    <2>1. C' <= n + 1
+        <3>1. Cardinality(S') <= Cardinality(S)
+            BY Zenon, <1>3, FS_Subset
+        <3>. HIDE DEF S
+        <3>. QED
+            BY <2>0, <3>1
+    <2>2. C' = n + 1 => r \in S'
+        <3>. SUFFICES ASSUME C' = n + 1
+                      PROVE S' = S
+            BY Zenon
+        <3>1. C' <= C
+            BY Zenon, <1>3, FS_Subset
+        <3>2. C' = C
+            <4>. HIDE DEF C, S
+            <4>. QED
+                BY <2>0, <3>1
+        <3>. QED
+            BY Zenon, <1>3, <3>2, FS_Subset
+    <2>. QED
+        BY Zenon, <2>1, <2>2
+<1>6. GraphSafetyInv /\ J /\ r \notin S => C < n + 1
+    BY <1>3, FS_CardinalityType
+<1>7. /\ []GraphSafetyInv /\ [][Next]_vars /\ []Fairness
+      /\ [](o \in objectTargets /\ o \in RegisteredObject)
+      /\ [][S' \subseteq S]_S
+      /\ []IsTaskUpstreamOnOpenPathToTarget(r, o)
+      => C = n + 1 /\ IsMRoot(o, r) ~> C < n + 1
+    <2>. TSpec == /\ []GraphSafetyInv /\ [][Next]_vars /\ []Fairness
+                  /\ [](o \in objectTargets /\ o \in RegisteredObject)
+                  /\ [][S' \subseteq S]_S
+                  /\ []IsTaskUpstreamOnOpenPathToTarget(r, o)
+    <2>1. r \in Task \/ r \in Object
+        OBVIOUS
+    <2>2. GraphSafetyInv /\ r \in Task /\ IsMRoot(o, r) => \/ r \in RegisteredTask
+                                                           \/ r \in StagedTask
+                                                           \/ r \in AssignedTask
+                                                           \/ r \in ProcessedTask
+        <3>. SUFFICES ASSUME GraphSafetyInv, r \in Task, IsMRoot(o, r)
+                      PROVE  \/ r \in RegisteredTask
+                             \/ r \in StagedTask
+                             \/ r \in AssignedTask
+                             \/ r \in ProcessedTask
+            OBVIOUS
+        <3>1. PICK p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r
+            OBVIOUS
+        <3>2. p \in SimplePath(deps)
+            BY <3>1 DEF MaximalOpenPath, OpenPath
+        <3>3. p \in Seq(deps.node) /\ Len(p) >= 1 /\ Len(p) \in Nat
+            BY <3>2, DG_SimplePathIsSeq
+        <3>4. 1 \in 1..Len(p)
+            BY <3>3
+        <3>5. r \in deps.node
+            BY <3>1, <3>3, <3>4, ElementOfSeq
+        <3>6. IsOpenNode(r)
+            BY <3>1, <3>4 DEF MaximalOpenPath, OpenPath
+        <3>7. r \notin UnknownTask
+            BY <3>5 DEF GraphSafetyInv, GraphStateIntegrity
+        <3>8. r \notin FinalizedTask
+            BY <3>6 DEF IsOpenNode
+        <3>9. taskState[r] \in TP1State
+            BY DEF GraphSafetyInv, TypeOk
+        <3>. QED
+            BY <3>7, <3>8, <3>9 DEF TP1State, UnknownTask, FinalizedTask,
+               RegisteredTask, StagedTask, AssignedTask, ProcessedTask,
+               TASK_UNKNOWN, TASK_REGISTERED, TASK_STAGED, TASK_ASSIGNED
+    <2>3. TSpec => (r \in Object /\ IsMRoot(o, r) ~> r \in FinalizedObject)
+        <3>1. /\ GraphSafetyInv /\ GraphSafetyInv'
+              /\ r \in Object /\ IsMRoot(o, r)
+              /\ IsTaskUpstreamOnOpenPathToTarget(r, o)'
+              /\ [Next]_vars /\ [S' \subseteq S]_S
+              => (r \in Object /\ IsMRoot(o, r))'
+            BY Zenon, LemMRootStable
+        <3>2. GraphSafetyInv /\ r \in Object /\ IsMRoot(o, r) => ENABLED <<FinalizeObjects({r})>>_vars
+            <4>. SUFFICES ASSUME GraphSafetyInv, r \in Object, IsMRoot(o, r)
+                          PROVE  ENABLED <<FinalizeObjects({r})>>_vars
+                OBVIOUS
+            <4>1. PICK p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r
+                OBVIOUS
+            <4>2. p \in SimplePath(deps)
+                BY <4>1 DEF MaximalOpenPath, OpenPath
+            <4>3. p \in Seq(deps.node) /\ Len(p) >= 1 /\ Len(p) \in Nat
+                BY <4>2, DG_SimplePathIsSeq
+            <4>4. 1 \in 1..Len(p)
+                BY <4>3
+            <4>5. r \in deps.node
+                BY <4>1, <4>3, <4>4, ElementOfSeq
+            <4>6. IsOpenNode(r)
+                BY <4>1, <4>4 DEF MaximalOpenPath, OpenPath
+            <4>7. \A u \in Predecessor(deps, r) : ~IsOpenNode(u)
+                BY <4>1 DEF MaximalOpenPath
+            <4>8. Predecessor(deps, r) \subseteq Task
+                BY <4>5, GP1Assumptions
+                   DEF GraphSafetyInv, DependencyGraphCompliant, IsDDGraph,
+                       IsBipartiteWithPartitions, Predecessor
+            <4>9. Predecessor(deps, r) \subseteq FinalizedTask
+                BY <4>7, <4>8, GP1Assumptions DEF IsOpenNode, FinalizedObject
+            <4>10. r \in RegisteredObject
+                BY <4>5, <4>6
+                   DEF GraphSafetyInv, GraphStateIntegrity, TypeOk, OP1State,
+                       IsOpenNode, UnknownObject, FinalizedObject, RegisteredObject
+            <4>11. r \in Source(deps)
+                BY <4>9, <4>10 DEF GraphSafetyInv, GraphStateIntegrity
+            <4>. QED
+                BY <4>10, <4>11, ExpandENABLED
+                   DEF FinalizeObjects, vars, RegisteredObject, Source
+        <3>3. <<FinalizeObjects({r})>>_vars => (r \in FinalizedObject)'
+            BY DEF FinalizeObjects, vars, FinalizedObject, RegisteredObject
+        <3>4. r \in Object /\ Fairness => WF_vars(FinalizeObjects({r}))
+            BY Isa DEF Fairness
+        <3>. QED
+            BY <3>1, <3>2, <3>3, <3>4, PTL
+    <2>4. TSpec => (r \in RegisteredTask /\ IsMRoot(o, r) ~> r \in StagedTask \/ r \in ProcessedTask)
+        <3>1. /\ GraphSafetyInv /\ GraphSafetyInv'
+              /\ r \in RegisteredTask /\ IsMRoot(o, r)
+              /\ IsTaskUpstreamOnOpenPathToTarget(r, o)'
+              /\ [Next]_vars /\ [S' \subseteq S]_S
+              => \/ (r \in RegisteredTask /\ IsMRoot(o, r))'
+                 \/ (r \in StagedTask)'
+                 \/ (r \in ProcessedTask)'
+            <4>. SUFFICES ASSUME GraphSafetyInv, GraphSafetyInv',
+                                 r \in RegisteredTask, IsMRoot(o, r),
+                                 IsTaskUpstreamOnOpenPathToTarget(r, o)',
+                                 [Next]_vars, [S' \subseteq S]_S
+                          PROVE  \/ (r \in RegisteredTask /\ IsMRoot(o, r))'
+                                 \/ (r \in StagedTask)'
+                                 \/ (r \in ProcessedTask)'
+                BY Zenon
+            <4>1. IsMRoot(o, r)'
+                BY Zenon, LemMRootStable
+            <4>2. \/ (r \in RegisteredTask)'
+                  \/ (r \in StagedTask)'
+                  \/ (r \in ProcessedTask)'
+                <5>1. r \in Task /\ taskState[r] = TASK_REGISTERED
+                    BY Zenon DEF RegisteredTask
+                <5>2. \/ taskState'[r] = TASK_REGISTERED
+                      \/ taskState'[r] = TASK_STAGED
+                      \/ taskState'[r] = TASK_PROCESSED
+                    BY Zenon, <5>1, LemTaskTransitions
+                       DEF TASK_UNKNOWN, TASK_REGISTERED, TASK_STAGED, TASK_ASSIGNED
+                <5>. QED
+                    BY Zenon, <5>1, <5>2 DEF RegisteredTask, StagedTask, ProcessedTask
+            <4>. QED
+                BY Zenon, <4>1, <4>2
+        <3>2. GraphSafetyInv /\ r \in RegisteredTask /\ IsMRoot(o, r) => ENABLED <<StageTasks({r})>>_vars
+            <4>. SUFFICES ASSUME GraphSafetyInv, r \in RegisteredTask, IsMRoot(o, r)
+                          PROVE  ENABLED <<StageTasks({r})>>_vars
+                OBVIOUS
+            <4>1. PICK p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r
+                OBVIOUS
+            <4>2. \A u \in Predecessor(deps, r) : ~IsOpenNode(u)
+                BY <4>1 DEF MaximalOpenPath
+            <4>3. p \in SimplePath(deps)
+                BY <4>1 DEF MaximalOpenPath, OpenPath
+            <4>4. p \in Seq(deps.node) /\ Len(p) >= 1 /\ Len(p) \in Nat
+                BY <4>3, DG_SimplePathIsSeq
+            <4>5. 1 \in 1..Len(p)
+                BY <4>4
+            <4>6. r \in deps.node
+                BY <4>1, <4>4, <4>5, ElementOfSeq
+            <4>7. Predecessor(deps, r) \subseteq Object
+                BY <4>6, GP1Assumptions
+                   DEF GraphSafetyInv, DependencyGraphCompliant, IsDDGraph,
+                       IsBipartiteWithPartitions, Predecessor, RegisteredTask
+            <4>8. Predecessor(deps, r) \subseteq FinalizedObject
+                BY <4>2, <4>7, GP1Assumptions DEF IsOpenNode, FinalizedTask
+            <4>. QED
+                BY <4>8, ExpandENABLED
+                   DEF StageTasks, vars, RegisteredTask, TASK_REGISTERED, TASK_STAGED
+        <3>3. <<StageTasks({r})>>_vars => (r \in StagedTask)'
+            BY DEF StageTasks, vars, StagedTask, RegisteredTask
+        <3>4. r \in RegisteredTask /\ Fairness => WF_vars(StageTasks({r}))
+            BY Isa DEF Fairness, RegisteredTask
+        <3>. QED
+            BY <3>1, <3>2, <3>3, <3>4, PTL
+    <2>5. TSpec => (r \in StagedTask ~> r \in AssignedTask \/ r \in ProcessedTask)
+        <3>1. GraphSafetyInv /\ r \in StagedTask /\ [Next]_vars
+              => (r \in StagedTask)' \/ (r \in AssignedTask)' \/ (r \in ProcessedTask)'
+            <4>. SUFFICES ASSUME r \in StagedTask, [Next]_vars
+                          PROVE  \/ (r \in StagedTask)'
+                                 \/ (r \in AssignedTask)'
+                                 \/ (r \in ProcessedTask)'
+                OBVIOUS
+            <4>1. r \in Task /\ taskState[r] = TASK_STAGED
+                BY DEF StagedTask
+            <4>2. \/ taskState'[r] = TASK_STAGED
+                  \/ taskState'[r] = TASK_ASSIGNED
+                  \/ taskState'[r] = TASK_PROCESSED
+                BY <4>1, LemTaskTransitions
+                   DEF TASK_UNKNOWN, TASK_REGISTERED, TASK_STAGED, TASK_ASSIGNED
+            <4>. QED
+                BY <4>1, <4>2 DEF StagedTask, AssignedTask, ProcessedTask
+        <3>2. r \in StagedTask /\ IsTaskUpstreamOnOpenPathToTarget(r, o)
+              => ENABLED <<(\E o2 \in Object : IsTaskUpstreamOnOpenPathToTarget(r, o2))
+                           /\ AssignTasks({r})>>_vars
+            <4>. SUFFICES ASSUME r \in StagedTask, IsTaskUpstreamOnOpenPathToTarget(r, o)
+                          PROVE  ENABLED <<(\E o2 \in Object : IsTaskUpstreamOnOpenPathToTarget(r, o2))
+                                           /\ AssignTasks({r})>>_vars
+                OBVIOUS
+            <4>1. \E o2 \in Object : IsTaskUpstreamOnOpenPathToTarget(r, o2)
+                OBVIOUS
+            <4>. QED
+                BY <4>1, ExpandENABLED
+                   DEF AssignTasks, vars, StagedTask, TASK_STAGED, TASK_ASSIGNED
+        <3>3. <<(\E o2 \in Object : IsTaskUpstreamOnOpenPathToTarget(r, o2))
+                /\ AssignTasks({r})>>_vars
+              => (r \in AssignedTask)'
+            BY DEF AssignTasks, vars, AssignedTask, StagedTask
+        <3>4. r \in StagedTask /\ Fairness => WF_vars((\E o2 \in Object : IsTaskUpstreamOnOpenPathToTarget(r, o2))
+                                                        /\ AssignTasks({r}))
+            BY Isa DEF Fairness, StagedTask
+        <3>. QED
+            BY <3>1, <3>2, <3>3, <3>4, PTL
+    <2>6 TSpec => []TP1!TypeOk /\ [][TP1!Next]_TP1!vars /\ TP1!Fairness
+        <3>1. GraphSafetyInv => TP1!TypeOk
+            BY DEF GraphSafetyInv, TypeOk, TP1State, TP1!TypeOk, TP1!TP1State
+        <3>. QED
+            BY <3>1, LemRefineTaskProcessing1Next, LemRefineTaskProcessing1Fairness, PTL
+    <2>7. TSpec => (r \in AssignedTask ~> r \in StagedTask \/ r \in ProcessedTask)
+        <3>0. /\ r \in AssignedTask <=> r \in TP1!AssignedTask
+              /\ r \in StagedTask <=> r \in TP1!StagedTask
+              /\ r \in ProcessedTask <=> r \in TP1!ProcessedTask
+            BY DEF AssignedTask, StagedTask, ProcessedTask, TP1!AssignedTask,
+            TP1!StagedTask, TP1!ProcessedTask
+        <3>1. r \in Task => (TSpec => (r \in AssignedTask ~> r \in StagedTask \/ r \in ProcessedTask))
+            <4>. SUFFICES ASSUME r \in Task
+                          PROVE TSpec => (r \in AssignedTask ~> r \in StagedTask \/ r \in ProcessedTask)
+                OBVIOUS
+            <4>1. []TP1!TypeOk /\ [][TP1!Next]_TP1!vars /\ TP1!Fairness => TP1!EventualDeallocation
+                BY SameAssumptions, TP1!LemEventualDeallocation, Isa DEF TP1!EventualDeallocation
+            <4>. DEFINE P(t) == t \in TP1!AssignedTask ~> t \in TP1!StagedTask \/ t \in TP1!ProcessedTask
+            <4>2. TP1!EventualDeallocation => \A t \in Task : P(t)
+                BY Isa DEF TP1!EventualDeallocation
+            <4>. HIDE DEF P
+            <4>3. (\A t \in Task : P(t)) => P(r)
+                OBVIOUS
+            <4>4. TP1!EventualDeallocation => P(r)
+                BY <4>2, <4>3, PTL
+            <4>. QED
+                BY <2>6, <3>0, <4>1, <4>4, PTL DEF P
+        <3>2. r \in Object => (TSpec => (r \in AssignedTask ~> r \in StagedTask \/ r \in ProcessedTask))
+            <4>. SUFFICES ASSUME r \in Object
+                          PROVE TSpec => (r \in AssignedTask ~> r \in StagedTask \/ r \in ProcessedTask)
+                OBVIOUS
+            <4>1. ~(r \in AssignedTask)
+                BY DEF AssignedTask
+            <4>. QED
+                BY <4>1, PTL
+        <3>. QED
+            BY <2>1, <3>1, <3>2, PTL
+    <2>8. TSpec => ([]<>(r \in AssignedTask) => <>(r \in ProcessedTask))
+        <3>0. /\ r \in AssignedTask <=> r \in TP1!AssignedTask
+              /\ r \in ProcessedTask <=> r \in TP1!ProcessedTask
+            BY DEF AssignedTask, ProcessedTask, TP1!AssignedTask, TP1!ProcessedTask
+        <3>1. r \in Task => (TSpec => ([]<>(r \in AssignedTask) => <>(r \in ProcessedTask)))
+            <4>. SUFFICES ASSUME r \in Task
+                          PROVE TSpec => ([]<>(r \in AssignedTask) => <>(r \in ProcessedTask))
+                OBVIOUS
+            <4>1. []TP1!TypeOk /\ [][TP1!Next]_TP1!vars /\ TP1!Fairness => TP1!EventualProcessing
+                BY SameAssumptions, TP1!LemEventualProcessing, Isa DEF TP1!EventualProcessing
+            <4>. DEFINE P(t) == []<>(t \in TP1!AssignedTask) => <>(t \in TP1!ProcessedTask)
+            <4>2. TP1!EventualProcessing => \A t \in Task : P(t)
+                BY Isa DEF TP1!EventualProcessing
+            <4>. HIDE DEF P
+            <4>3. (\A t \in Task : P(t)) => P(r)
+                OBVIOUS
+            <4>4. TP1!EventualProcessing => P(r)
+                BY <4>2, <4>3, PTL
+            <4>. QED
+                BY <2>6, <3>0, <4>1, <4>4, PTL DEF P
+        <3>2. r \in Object => (TSpec => ([]<>(r \in AssignedTask) => <>(r \in ProcessedTask)))
+            <4>. SUFFICES ASSUME r \in Object
+                          PROVE TSpec => ([]<>(r \in AssignedTask) => <>(r \in ProcessedTask))
+                OBVIOUS
+            <4>1. ~(r \in AssignedTask)
+                BY DEF AssignedTask
+            <4>. QED
+                BY <4>1, PTL
+        <3>. QED
+            BY <2>1, <3>1, <3>2, PTL
+    <2>9. TSpec => (r \in ProcessedTask ~> r \in FinalizedTask)
+        <3>0. /\ r \in ProcessedTask <=> r \in TP1!ProcessedTask
+              /\ r \in FinalizedTask <=> r \in TP1!FinalizedTask
+            BY DEF ProcessedTask, FinalizedTask, TP1!ProcessedTask, TP1!FinalizedTask
+        <3>1. r \in Task => (TSpec => (r \in ProcessedTask ~> r \in FinalizedTask))
+            <4>. SUFFICES ASSUME r \in Task
+                          PROVE TSpec => (r \in ProcessedTask ~> r \in FinalizedTask)
+                OBVIOUS
+            <4>1. []TP1!TypeOk /\ [][TP1!Next]_TP1!vars /\ TP1!Fairness => TP1!EventualFinalization
+                BY SameAssumptions, TP1!LemEventualFinalization, Isa DEF TP1!EventualFinalization
+            <4>. DEFINE P(t) == t \in TP1!ProcessedTask ~> t \in TP1!FinalizedTask
+            <4>2. TP1!EventualFinalization => \A t \in Task : P(t)
+                BY Isa DEF TP1!EventualFinalization
+            <4>. HIDE DEF P
+            <4>3. (\A t \in Task : P(t)) => P(r)
+                OBVIOUS
+            <4>4. TP1!EventualFinalization => P(r)
+                BY <4>2, <4>3, PTL
+            <4>. QED
+                BY <2>6, <3>0, <4>1, <4>4, PTL DEF P
+        <3>2. r \in Object => (TSpec => (r \in ProcessedTask ~> r \in FinalizedTask))
+            <4>. SUFFICES ASSUME r \in Object
+                          PROVE TSpec => (r \in ProcessedTask ~> r \in FinalizedTask)
+                OBVIOUS
+            <4>1. ~(r \in ProcessedTask)
+                BY DEF ProcessedTask
+            <4>. QED
+                BY <4>1, PTL
+        <3>. QED
+            BY <2>1, <3>1, <3>2, PTL
+    <2>10. /\ r \in FinalizedObject => r \notin S
+           /\ r \in FinalizedTask => r \notin S
+        <3>1. S \subseteq {m \in deps.node : IsOpenNode(m)}
+            BY DEF AncestorSubGraph, Ancestor
+        <3>. QED
+            BY <3>1 DEF IsOpenNode
+    <2>11. ~(r \in StagedTask /\ r \in AssignedTask)
+        BY DEF StagedTask, AssignedTask, TASK_STAGED, TASK_ASSIGNED
+    <2>. QED
+        BY <1>2, <1>4, <1>5, <1>6, <2>1, <2>2, <2>3, <2>4, <2>5, <2>7, <2>8, <2>9,
+        <2>10, <2>11, PTL
+<1>8. /\ []GraphSafetyInv /\ [][Next]_vars /\ []Fairness
+      /\ [](o \in objectTargets /\ o \in RegisteredObject)
+      /\ [][S' \subseteq S]_S
+      => C = n + 1 /\ IsMRoot(o, r) /\ <>~IsTaskUpstreamOnOpenPathToTarget(r, o) ~> C < n + 1
+    <2>1. GraphSafetyInv /\ o \in objectTargets /\ ~IsTaskUpstreamOnOpenPathToTarget(r, o)
+          => r \notin S
+        <3>. SUFFICES ASSUME GraphSafetyInv, o \in objectTargets,
+                                ~IsTaskUpstreamOnOpenPathToTarget(r, o)
+                        PROVE  r \notin S
+            OBVIOUS
+        <3>1. IsDirectedGraph(deps)
+            BY DEF GraphSafetyInv, DependencyGraphCompliant, IsDDGraph, IsDag
+        <3>2. OpenSubGraph(deps, o, IsOpenNode) = AncestorSubGraph(deps, o, IsOpenNode)
+            BY Zenon, <3>1, DDG_OpenSubGraphEqualsAncestorSubGraph
+        <3>3. S = OpenSubGraph(deps, o, IsOpenNode).node
+            BY <3>2
+        <3>4. OpenSubGraph(deps, o, IsOpenNode).node
+              = {p[1] : p \in OpenPath(deps, o, IsOpenNode)}
+            BY DEF OpenSubGraph
+        <3>5. ~\E p \in OpenPath(deps, o, IsOpenNode) : p[1] = r
+            BY DEF IsTaskUpstreamOnOpenPathToTarget
+        <3>. QED
+            BY <3>3, <3>4, <3>5
+    <2>. QED
+        BY <1>2, <1>4, <1>5, <1>6, <2>1, PTL
+<1>. QED
+    BY <1>1, <1>7, <1>8, PTL
+
+LEMMA LemCardinalityDescent ==
+    ASSUME NEW o \in Object, NEW n \in Nat
+    PROVE LET S == AncestorSubGraph(deps, o, IsOpenNode).node
+              C == Cardinality(S)
+          IN /\ []GraphSafetyInv /\ [][Next]_vars /\ []Fairness
+             /\ [](o \in objectTargets /\ o \in RegisteredObject)
+             /\ [][S' \subseteq S]_S
+             => C = n + 1 ~> C < n + 1
+<1>. DEFINE S == AncestorSubGraph(deps, o, IsOpenNode).node
+            C == Cardinality(S)
+            IsMRoot(o, r) == \E p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r
+            F == /\ []GraphSafetyInv
+                 /\ [][Next]_vars 
+                 /\ []Fairness
+                 /\ [](o \in objectTargets /\ o \in RegisteredObject)
+                 /\ [][S' \subseteq S]_S
+<1>1. GraphSafetyInv /\ o \in RegisteredObject
+      => \E r \in Task \union Object : IsMRoot(o, r)
+    <2>. SUFFICES ASSUME GraphSafetyInv, o \in RegisteredObject
+                  PROVE  \E r \in Task \union Object : IsMRoot(o, r)
+        OBVIOUS
+    <2>1. o \in deps.node
+        BY DEF GraphSafetyInv, GraphStateIntegrity, RegisteredObject, UnknownObject
+    <2>2. IsOpenNode(o)
+        BY GP1Assumptions DEF IsOpenNode, RegisteredObject, FinalizedObject,
+        FinalizedTask
+    <2>3. OpenPath(deps, o, IsOpenNode) # {}
+        BY Isa, <2>1, <2>2, DDG_OpenPathEmpty
+    <2>4. IsDag(deps) /\ IsFiniteSet(deps.node)
+        BY DEF GraphSafetyInv, DependencyGraphCompliant, DependencyGraphFinite, IsDDGraph
+    <2>5. PICK p \in MaximalOpenPath(deps, o, IsOpenNode) : TRUE
+        BY Zenon, <2>3, <2>4, DDG_MaximalOpenPathExists
+    <2>6. p \in SimplePath(deps)
+        BY <2>5 DEF MaximalOpenPath, OpenPath
+    <2>7. p[1] \in deps.node
+        BY <2>6, DG_SimplePathIsSeq, ElementOfSeq
+    <2>8. p[1] \in Task \union Object
+        BY <2>7 DEF GraphSafetyInv, TypeOk, DirectedGraphOf
+    <2>9. IsMRoot(o, p[1])
+        BY <2>5 DEF IsMRoot
+    <2>. QED
+        BY <2>8, <2>9
+<1>2. \A r \in Task \union Object : F => C = n + 1 /\ IsMRoot(o, r) ~> C < n + 1
+    BY LemRootProgress
+<1>3. (\A r \in Task \union Object :  (F => C = n + 1 /\ IsMRoot(o, r) ~> C < n + 1))
+      => F => C = n + 1 /\ (\E r \in Task \union Object : IsMRoot(o, r)) ~> C < n + 1
+    <2>1. (\A r \in Task \union Object : (F => C = n + 1 /\ IsMRoot(o, r) ~> C < n + 1))
+          => (F => \A r \in Task \union Object : (C = n + 1 /\ IsMRoot(o, r) ~> C < n + 1))
+        OBVIOUS
+    <2>2. (\A r \in Task \union Object : (C = n + 1 /\ IsMRoot(o, r) ~> C < n + 1))
+          => (C = n + 1 /\ (\E r \in Task \union Object : IsMRoot(o, r)) ~> C < n + 1)
+        <3>1. (\A r \in Task \union Object : (C = n + 1 /\ IsMRoot(o, r) ~> C < n + 1))
+              => \A r \in Task \union Object : [](C = n + 1 /\ IsMRoot(o, r) => <>(C < n + 1))
+            <5>. SUFFICES ASSUME NEW r \in Task \union Object, C = n + 1 /\ IsMRoot(o, r) ~> C < n + 1
+                            PROVE [](C = n + 1 /\ IsMRoot(o, r) => <>(C < n + 1))
+                OBVIOUS
+            <5>. QED
+                BY PTL
+        <3>2. (\A r \in Task \union Object : [](C = n + 1 /\ IsMRoot(o, r) => <>(C < n + 1)))
+                => [](\A r \in Task \union Object : C = n + 1 /\ IsMRoot(o, r) => <>(C < n + 1))
+            OBVIOUS
+        <3>3. (\A r \in Task \union Object : C = n + 1 /\ IsMRoot(o, r) => <>(C < n + 1))
+                => C = n + 1 /\ (\E r \in Task \union Object : IsMRoot(o, r)) => <>(C < n + 1)
+            OBVIOUS
+        <3>. QED
+            BY <3>1, <3>2, <3>3, PTL
+    <2>. QED
+        BY <2>1, <2>2
+<1>. QED
+    BY <1>1, <1>2, <1>3, PTL
+
 THEOREM GP1_RefineObjectProcessing1 == Spec => RefineObjectProcessing1
-<1>. USE DEF OP1!OBJECT_UNKNOWN, OP1!OBJECT_REGISTERED, OP1!OBJECT_FINALIZED
+<1>. USE DEF OP1!OBJECT_UNKNOWN, OP1!OBJECT_REGISTERED, OP1!OBJECT_FINALIZED,
+     TP1!TASK_UNKNOWN, TP1!TASK_REGISTERED, TP1!TASK_STAGED, TP1!TASK_ASSIGNED,
+     TP1!TASK_PROCESSED, TP1!TASK_FINALIZED
 <1>1. Init => OP1!Init
     BY DEF Init, OP1!Init
 <1>2. GraphSafetyInv /\ [Next]_vars => [OP1!Next]_OP1!vars
@@ -1639,7 +2371,141 @@ THEOREM GP1_RefineObjectProcessing1 == Spec => RefineObjectProcessing1
         BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8, <2>9, <2>10, <2>11, <2>12
         DEF Next, OP1!Next
 <1>3. []GraphSafetyInv /\ [][Next]_vars /\ Fairness /\ OpenUpstreamEventuallyClosed => OP1!Fairness
-    PROOF OMITTED
+    <2>. USE GP1Assumptions 
+    <2>. DEFINE AG(o) == AncestorSubGraph(deps, o, IsOpenNode)
+    <2>. SUFFICES ASSUME NEW o \in Object
+                  PROVE /\ []GraphSafetyInv
+                        /\ [][Next]_vars
+                        /\ Fairness
+                        /\ []([](o \in objectTargets) => <>[][(AG(o).node)' \subseteq AG(o).node]_(AG(o).node))
+                        => WF_OP1!vars(o \in objectTargets /\ OP1!FinalizeObjects({o}))
+        BY Isa DEF OP1!Fairness, OpenUpstreamEventuallyClosed
+    <2>0. Fairness <=> []Fairness
+        <3>1. (\A o \in Object : WF_vars(FinalizeObjects({o})))
+               <=> [](\A o \in Object : WF_vars(FinalizeObjects({o})))
+            <4>1. [](\A o \in Object : WF_vars(FinalizeObjects({o})))
+                  <=> \A o \in Object : [](WF_vars(FinalizeObjects({o})))
+                OBVIOUS
+            <4>2. ASSUME NEW o \in Object
+                  PROVE [](WF_vars(FinalizeObjects({o})))
+                        <=> WF_vars(FinalizeObjects({o}))
+                BY PTL
+            <4>. QED
+                BY <4>1, <4>2, Isa
+        <3>. DEFINE TaskFairness(t) ==
+                        /\ WF_vars(StageTasks({t}))
+                        /\ WF_vars(
+                            /\ \E o \in Object : IsTaskUpstreamOnOpenPathToTarget(t, o)
+                            /\ AssignTasks({t}))
+                        /\ SF_vars(ProcessTasks({t}))
+                        /\ WF_vars(FinalizeTasks({t}))
+        <3>2. (\A t \in Task : TaskFairness(t))
+               <=> [](\A t \in Task : TaskFairness(t))
+            <4>1. [](\A t \in Task : TaskFairness(t))
+                  <=> \A t \in Task : []TaskFairness(t)
+                OBVIOUS
+            <4>2. ASSUME NEW t \in Task
+                  PROVE []TaskFairness(t)
+                        <=> TaskFairness(t)
+                BY PTL
+            <4>. QED
+                BY <4>1, <4>2, Isa
+        <3>. QED
+            BY <3>1, <3>2, PTL DEF Fairness
+    <2>. DEFINE S == AG(o).node
+                C == Cardinality(S)
+    <2>. SUFFICES /\ []GraphSafetyInv
+                  /\ [][Next]_vars 
+                  /\ []Fairness
+                  /\ [](o \in objectTargets /\ o \in RegisteredObject)
+                  /\ [][S' \subseteq S]_S
+                  => FALSE
+        <3>1. []([](o \in objectTargets) => <>[][S' \subseteq S]_S)
+              => [](o \in objectTargets) => <>[][S' \subseteq S]_S
+            BY PTL
+        <3>2. ENABLED <<o \in objectTargets /\ OP1!FinalizeObjects({o})>>_OP1!vars
+              => o \in objectTargets /\ o \in RegisteredObject
+            BY ExpandENABLED DEF OP1!FinalizeObjects, OP1!vars, RegisteredObject, OP1!RegisteredObject
+        <3>. QED
+            BY <3>1, <3>2, <2>0, PTL DEF OpenUpstreamEventuallyClosed
+    <2>. DEFINE F == /\ []GraphSafetyInv
+                     /\ [][Next]_vars 
+                     /\ []Fairness
+                     /\ [](o \in objectTargets /\ o \in RegisteredObject)
+                     /\ [][S' \subseteq S]_S
+    <2>0. GraphSafetyInv /\ o \in RegisteredObject
+          => IsFiniteSet(S) /\ C \in Nat /\ C >= 1
+        <3>. SUFFICES ASSUME GraphSafetyInv, o \in RegisteredObject
+                      PROVE  IsFiniteSet(S) /\ C \in Nat /\ C >= 1
+            OBVIOUS
+        <3>1. IsDirectedGraph(deps)
+            BY DEF GraphSafetyInv, DependencyGraphCompliant, IsDDGraph, IsDag
+        <3>2. S \subseteq deps.node
+            BY Zenon, <3>1, DDG_AncestorSubGraphBasic DEF DirectedSubgraph
+        <3>3. IsFiniteSet(S)
+            BY <3>2, FS_Subset DEF GraphSafetyInv, DependencyGraphFinite
+        <3>4. o \in deps.node
+            BY DEF GraphSafetyInv, GraphStateIntegrity, RegisteredObject, UnknownObject
+        <3>5. IsOpenNode(o)
+            BY DEF IsOpenNode, RegisteredObject, FinalizedObject, FinalizedTask
+        <3>6. o \in S
+            BY Isa, <3>4, <3>5, DDG_AncestorSubGraphEmpty
+        <3>. QED
+            BY <3>3, <3>6, FS_EmptySet, FS_CardinalityType
+    <2>1. GraphSafetyInv /\ o \in RegisteredObject => \E n \in Nat : C <= n
+        BY <2>0
+    <2>2. \A n \in Nat : F => (C <= n) ~> FALSE
+        <3>. DEFINE Q(k) == F => (C <= k) ~> FALSE
+        <3>1. Q(0)
+            <4>1. GraphSafetyInv /\ o \in RegisteredObject
+                  => C \in Nat /\ C >= 1
+                BY <2>0
+            <4>2. (C \in Nat /\ C >= 1) => ~(C <= 0)
+                OBVIOUS
+            <4>. QED
+                BY <4>1, <4>2, PTL
+        <3>2. \A n \in Nat : Q(n) => Q(n+1)
+            <4>. TAKE n \in Nat
+            <4>1. F => C = n + 1 ~> C < n + 1
+                BY LemCardinalityDescent
+            <4>2. C \in Nat => (C < n + 1 => C <= n)
+                OBVIOUS
+            <4>3. C \in Nat => (C <= n + 1 => C <= n \/ C = n + 1)
+                OBVIOUS
+            <4>. QED
+                BY <2>0, <4>1, <4>2, <4>3, PTL
+        <3>3. \A n \in Nat : Q(n)
+            <4>. HIDE DEF Q
+            <4>. QED
+                BY <3>1, <3>2, NatInduction, IsaM("blast")
+        <3>. QED
+            BY <3>3
+    <2>3. (\A n \in Nat :  (F => C <= n ~> FALSE))
+          => F => (\E n \in Nat : C <= n) ~> FALSE
+        <3>1. (\A n \in Nat :  (F => C <= n ~> FALSE))
+              => (F => \A n \in Nat : (C <= n ~> FALSE))
+            OBVIOUS
+        <3>2. (\A n \in Nat : (C <= n ~> FALSE))
+              => ((\E n \in Nat : C <= n) ~> FALSE)
+            <4>1. (\A n \in Nat : (C <= n ~> FALSE))
+                  => \A n \in Nat : [](C <= n => <>FALSE)
+                <5>. SUFFICES ASSUME NEW n \in Nat, C <= n ~> FALSE
+                              PROVE [](C <= n => <>FALSE)
+                    OBVIOUS
+                <5>. QED
+                    BY PTL
+            <4>2. (\A n \in Nat : [](C <= n => <>FALSE))
+                  => [](\A n \in Nat : C <= n => <>FALSE)
+                OBVIOUS
+            <4>3. (\A n \in Nat : C <= n => <>FALSE)
+                  => (\E n \in Nat : C <= n) => <>FALSE
+                OBVIOUS
+            <4>. QED
+                BY <4>1, <4>2, <4>3, PTL
+        <3>. QED
+            BY <3>1, <3>2
+    <2>. QED
+        BY <2>1, <2>2, <2>3, PTL
 <1>. QED
     BY <1>1, <1>2, <1>3, GP1_GraphSafetyInv, PTL DEF Spec, OP1!Spec, RefineObjectProcessing1
 

--- a/specs/TaskProcessing1Theorems.tla
+++ b/specs/TaskProcessing1Theorems.tla
@@ -1,0 +1,30 @@
+----------------------- MODULE TaskProcessing1Theorems -------------------------
+EXTENDS TaskProcessing1
+
+LEMMA LemType == Init /\ [][Next]_vars => []TypeOk
+
+THEOREM TP1_Type == Spec => []TypeOk
+
+THEOREM TP1_PermanentFinalization == Spec => PermanentFinalization
+
+LEMMA AssignmentEnablesProcessing ==
+        ASSUME NEW t \in Task, TypeOk
+        PROVE t \in AssignedTask
+              => ENABLED <<ProcessTasks({t})>>_vars
+
+LEMMA LemEventualDeallocation ==
+    []TypeOk /\ [][Next]_vars /\ Fairness => EventualDeallocation
+
+THEOREM TP1_EventualDeallocation == Spec => EventualDeallocation
+
+LEMMA LemEventualProcessing == []TypeOk /\ [][Next]_vars /\ Fairness => EventualProcessing
+
+THEOREM TP1_EventualProcessing == Spec => EventualProcessing
+
+LEMMA LemEventualFinalization == []TypeOk /\ [][Next]_vars /\ Fairness => EventualFinalization
+
+THEOREM TP1_EventualFinalization == Spec => EventualFinalization
+
+THEOREM TP1_EventualQuiescence == Spec => EventualQuiescence
+
+================================================================================

--- a/specs/TaskProcessing1_proofs.tla
+++ b/specs/TaskProcessing1_proofs.tla
@@ -37,10 +37,10 @@ LEMMA AssignmentEnablesProcessing ==
               => ENABLED <<ProcessTasks({t})>>_vars
 BY ExpandENABLED DEF ProcessTasks, AssignedTask, vars
 
-THEOREM TP1_EventualDeallocation == Spec => EventualDeallocation
+LEMMA LemEventualDeallocation == []TypeOk /\ [][Next]_vars /\ Fairness => EventualDeallocation
 <1>. SUFFICES ASSUME NEW t \in Task
-              PROVE Spec => t \in AssignedTask
-                            ~> t \in StagedTask \/ t \in ProcessedTask
+              PROVE []TypeOk /\ [][Next]_vars /\ Fairness
+                    => t \in AssignedTask ~> t \in StagedTask \/ t \in ProcessedTask
     BY DEF EventualDeallocation
 <1>1. t \in AssignedTask /\ [Next]_vars => \/ (t \in AssignedTask)'
                                            \/ (t \in StagedTask)'
@@ -70,11 +70,15 @@ THEOREM TP1_EventualDeallocation == Spec => EventualDeallocation
 <1>4. Fairness => SF_vars(ProcessTasks({t}))
     BY Isa DEF Fairness
 <1>. QED
-    BY <1>1, <1>2, <1>3, <1>4, TP1_Type, PTL DEF Spec
+    BY <1>1, <1>2, <1>3, <1>4, PTL
 
-THEOREM TP1_EventualProcessing == Spec => EventualProcessing
+THEOREM TP1_EventualDeallocation == Spec => EventualDeallocation
+BY LemEventualDeallocation, TP1_Type, PTL DEF Spec
+
+LEMMA LemEventualProcessing == []TypeOk /\ [][Next]_vars /\ Fairness => EventualProcessing
 <1>. SUFFICES ASSUME NEW t \in Task
-              PROVE Spec => ([]<>(t \in AssignedTask) => <>(t \in ProcessedTask))
+              PROVE []TypeOk /\ [][Next]_vars /\ Fairness
+                    => ([]<>(t \in AssignedTask) => <>(t \in ProcessedTask))
     BY DEF EventualProcessing
 <1>1. TypeOk /\ t \in AssignedTask
       => ENABLED <<ProcessTasks({t})>>_vars
@@ -85,11 +89,15 @@ THEOREM TP1_EventualProcessing == Spec => EventualProcessing
 <1>3. Fairness => SF_vars(ProcessTasks({t}))
     BY Isa DEF Fairness
 <1>. QED
-    BY <1>1, <1>2, <1>3, TP1_Type, PTL DEF Spec
+    BY <1>1, <1>2, <1>3, PTL
 
-THEOREM TP1_EventualFinalization == Spec => EventualFinalization
+THEOREM TP1_EventualProcessing == Spec => EventualProcessing
+BY LemEventualProcessing, TP1_Type, PTL DEF Spec
+
+LEMMA LemEventualFinalization == []TypeOk /\ [][Next]_vars /\ Fairness => EventualFinalization
 <1>. SUFFICES ASSUME NEW t \in Task
-                PROVE Spec => t \in ProcessedTask ~> t \in FinalizedTask
+                PROVE []TypeOk /\ [][Next]_vars /\ Fairness
+                      => t \in ProcessedTask ~> t \in FinalizedTask
     BY DEF EventualFinalization
 <1>1. TypeOk /\ t \in ProcessedTask /\ [Next]_vars
       => (t \in ProcessedTask)' \/ (t \in FinalizedTask)'
@@ -104,7 +112,10 @@ THEOREM TP1_EventualFinalization == Spec => EventualFinalization
 <1>4. Fairness => WF_vars(FinalizeTasks({t}))
     BY Isa DEF Fairness
 <1>. QED
-    BY <1>1, <1>2, <1>3, <1>4, TP1_Type, PTL DEF Spec
+    BY <1>1, <1>2, <1>3, <1>4, PTL
+
+THEOREM TP1_EventualFinalization == Spec => EventualFinalization
+BY LemEventualFinalization, TP1_Type, PTL DEF Spec
 
 THEOREM TP1_EventualQuiescence == Spec => EventualQuiescence
 <1>. SUFFICES ASSUME NEW t \in Task


### PR DESCRIPTION
## Summary

Completes the machine-checked proof that `GraphProcessing1` refines
`ObjectProcessing1` — `THEOREM GP1_RefineObjectProcessing1 == Spec =>
RefineObjectProcessing1` is now fully proved in `GraphProcessing1_proofs.tla` with **no `OMITTED` or
unproved steps**. The whole module is checked by TLAPM (all obligations proved).

The core of the work is the liveness argument for `OP1!Fairness`: the open
ancestor subgraph of a registered, targeted object keeps strictly losing nodes,
which is impossible on a finite, monotone-non-increasing set — driving every
targeted object to eventual finalization.

## What's included

**`GraphProcessing1_proofs.tla`** (main result)
- `GP1_RefineObjectProcessing1` step `<1>3` (`OP1!Fairness`) fully discharged via
  a Cardinality state-measure descent (well-founded `NatInduction`).
- Supporting lemmas:
  - `LemRootProgress` / `LemCardinalityDescent` — per-root and existential
    open-ancestor cardinality descent.
  - `LemMRootStable` — a maximal-open-path root stays a root across any step while
    it remains upstream of the target (the only threat, a `RegisterGraph` adding an
    open parent, is ruled out by the subgraph-monotonicity hypothesis).
  - `LemTaskTransitions` / `LemObjectTransitions` — per-variable lifecycle
    transition relations under `[Next]_vars`.
  - `OpPrimed` — next-state openness predicate enabling the DDGraph library lemmas
    to be applied to `deps'`.
- `GP1_RefineTaskProcessing1` refactored: its Next/Fairness refinement steps are
  extracted into reusable lemmas `LemRefineTaskProcessing1Next` /
  `LemRefineTaskProcessing1Fairness`, and the task-lifecycle leads-to steps are
  discharged through the TaskProcessing1 refinement.
**`TaskProcessing1Theorems.tla`** (new)
- Exposes the TaskProcessing1 liveness lemmas (`LemEventualDeallocation`,
  `LemEventualProcessing`, `LemEventualFinalization`, …) as a theorems module so
  `GraphProcessing1` can consume them through its `TP1` instance.
**`DDGraphs.tla` / `DDGraphTheorems(_proofs).tla`**
- Adds `MaximalOpenPath` / `OpenSubGraph` operators and their theorems
  (`DDG_MaximalOpenPathExists`, `DDG_MaximalOpenPathSuffixEquiv`,
  `DDG_OpenSubGraphEqualsAncestorSubGraph`, …) used by the liveness proof.
**`TaskProcessing1_proofs.tla`**
- Liveness theorems restructured into reusable lemmas over
  `[]TypeOk /\ [][Next]_vars /\ Fairness`.
