### PR TITLE
refactor: declare theorems in dedicated XTheorems modules

### DIFF
--- a/specs/GraphProcessing1.tla
+++ b/specs/GraphProcessing1.tla
@@ -400,20 +400,4 @@ OP1 == INSTANCE ObjectProcessing1
 RefineObjectProcessing1 ==
     OP1!Spec
 
--------------------------------------------------------------------------------
-
-(*****************************************************************************)
-(* THEOREMS                                                                  *)
-(*****************************************************************************)
-
-THEOREM Spec => []TypeOk
-THEOREM Spec => []DependencyGraphCompliant
-THEOREM Spec => []GraphStateIntegrity
-THEOREM Spec => []DependencyGraphFinite
-THEOREM Spec => FinalizedSourcesInvariant
-THEOREM Spec => TaskDataDependenciesInvariant
-THEOREM Spec => CommittedObjectsEventualFinalization
-THEOREM Spec => RefineTaskProcessing1
-THEOREM Spec => RefineObjectProcessing1
-
 ================================================================================

--- a/specs/GraphProcessing1Theorems.tla
+++ b/specs/GraphProcessing1Theorems.tla
@@ -1,0 +1,162 @@
+----------------------- MODULE GraphProcessing1Theorems ------------------------
+EXTENDS GraphProcessing1
+
+LEMMA SameAssumptions == GP1Assumptions => TP1!TP1Assumptions
+
+(*****************************************************************************)
+
+LEMMA LemType == Init /\ [][Next]_vars => []TypeOk
+
+THEOREM GP1_Type == Spec => []TypeOk
+
+(*****************************************************************************)
+
+LEMMA LemDependencyGraphCompliant == Init /\ [][Next]_vars => []DependencyGraphCompliant
+
+THEOREM GP1_DependencyGraphCompliant == Spec => []DependencyGraphCompliant
+
+(**
+ * Helper: under GraphStateIntegrity, every registered or finalized object is
+ * already a node of the dependency graph. A non-node object is vacuously a
+ * non-source with an empty predecessor set, which the integrity invariant
+ * forbids for registered/finalized objects.
+ *)
+LEMMA RegFinInGraph ==
+    ASSUME TypeOk, GraphStateIntegrity
+    PROVE  /\ RegisteredObject \subseteq deps.node
+           /\ FinalizedObject \subseteq deps.node
+
+LEMMA LemGraphStateIntegrity == Init /\ [][Next]_vars => []GraphStateIntegrity
+
+THEOREM GP1_GraphStateIntegrity == Spec => []GraphStateIntegrity
+
+(*****************************************************************************)
+
+LEMMA LemDependencyGraphFinite == Init /\ [][Next]_vars => []DependencyGraphFinite
+
+THEOREM GP1_DependencyGraphFinite == Spec => []DependencyGraphFinite
+
+LEMMA LemTaskDependenciesFinite ==
+    ASSUME DependencyGraphFinite, NEW t \in Task
+    PROVE /\ IsFiniteSet(Predecessor(deps, t))
+          /\ IsFiniteSet(Successor(deps, t))
+
+(**
+ * Corollary (the original per-task finiteness property): every task has a
+ * finite number of input and output data dependencies, since both are subsets
+ * of the finite node set.
+ *)
+THEOREM GP1_TaskDependenciesFinite ==
+    Spec => [](\A t \in Task : /\ IsFiniteSet(Predecessor(deps, t))
+                               /\ IsFiniteSet(Successor(deps, t)))
+
+(*****************************************************************************)
+
+THEOREM GP1_FinalizedSourcesInvariant == Spec => FinalizedSourcesInvariant
+
+(*****************************************************************************)
+
+THEOREM GP1_TaskDataDependenciesInvariant == Spec => TaskDataDependenciesInvariant
+
+(**
+ * LIVENESS. A known object whose producing tasks have all been processed or
+ * finalized is eventually finalized, provided it never gains a new producer.
+ * Object fairness fires FinalizeObjects; the guard "no future RegisterGraph
+ * produces o" keeps the producer set fixed, the processed/finalized producers
+ * persist, and a registered object always has a processed producer (or is a
+ * finalizable source), so FinalizeObjects stays enabled until it fires
+ * (weak-fairness lattice rule WF1, with the RegisterGraph guard threaded as in
+ * TaskProcessing3.PermanentStopping).
+ *)
+THEOREM GP1_CommittedObjectsEventualFinalization == Spec => CommittedObjectsEventualFinalization
+
+(*****************************************************************************)
+
+GraphSafetyInv ==
+    /\ TypeOk
+    /\ DependencyGraphCompliant
+    /\ GraphStateIntegrity
+    /\ DependencyGraphFinite
+
+THEOREM GP1_GraphSafetyInv == Spec => []GraphSafetyInv
+
+(*****************************************************************************)
+
+LEMMA LemStableTaskSuccessors ==
+    ASSUME NEW t \in Task, NEW S, GraphSafetyInv
+    PROVE ~ t \in UnknownTask /\ S = Successor(deps, t) /\ [Next]_vars => (S = Successor(deps, t))'
+
+LEMMA LemRefineTaskProcessing1Next ==
+    GraphSafetyInv /\ [Next]_vars => [TP1!Next]_(TP1!vars)
+
+LEMMA LemRefineTaskProcessing1Fairness ==
+    [][Next]_vars /\ []GraphSafetyInv /\ Fairness => TP1!Fairness
+
+THEOREM GP1_RefineTaskProcessing1 == Spec => RefineTaskProcessing1
+
+(**
+ * Transition relation of taskState[t] under any system step: a task either
+ * keeps its state or follows the registered -> staged/processed ->
+ * assigned/processed -> finalized lifecycle.
+ *)
+LEMMA LemTaskTransitions ==
+    ASSUME NEW t \in Task
+    PROVE [Next]_vars =>
+            \/ taskState'[t] = taskState[t]
+            \/ taskState[t] = TASK_UNKNOWN /\ taskState'[t] = TASK_REGISTERED
+            \/ taskState[t] = TASK_REGISTERED /\ taskState'[t] \in {TASK_STAGED, TASK_PROCESSED}
+            \/ taskState[t] = TASK_STAGED /\ taskState'[t] \in {TASK_ASSIGNED, TASK_PROCESSED}
+            \/ taskState[t] = TASK_ASSIGNED /\ taskState'[t] \in {TASK_STAGED, TASK_PROCESSED}
+            \/ taskState[t] = TASK_PROCESSED /\ taskState'[t] = TASK_FINALIZED
+
+(**
+ * Transition relation of objectState[x] under any system step: an object
+ * either keeps its state or follows unknown -> registered -> finalized.
+ *)
+LEMMA LemObjectTransitions ==
+    ASSUME NEW x \in Object
+    PROVE [Next]_vars =>
+            \/ objectState'[x] = objectState[x]
+            \/ objectState[x] = OBJECT_UNKNOWN /\ objectState'[x] = OBJECT_REGISTERED
+            \/ objectState[x] = OBJECT_REGISTERED /\ objectState'[x] = OBJECT_FINALIZED
+
+(**
+ * STABILITY OF MAXIMAL-OPEN-PATH ROOTS. While r stays upstream of o on an
+ * open path, being the root of a maximal open path to o is preserved by every
+ * system step, provided the open ancestor set S of o never gains a node.
+ * Indeed the only threat is RegisterGraph attaching a new producing task
+ * above r: that task is freshly registered (hence open) and, r being an open
+ * ancestor of o, it would become a new open ancestor of o -- enlarging S,
+ * which [S' \subseteq S]_S forbids. All other steps leave the predecessors of
+ * r untouched, and closed (finalized) predecessors stay closed forever.
+ *)
+LEMMA LemMRootStable ==
+    ASSUME NEW o \in Object, NEW r \in Object \union Task
+    PROVE LET S == AncestorSubGraph(deps, o, IsOpenNode).node
+          IN /\ GraphSafetyInv /\ GraphSafetyInv'
+             /\ [Next]_vars /\ [S' \subseteq S]_S
+             /\ \E p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r
+             /\ IsTaskUpstreamOnOpenPathToTarget(r, o)'
+             => (\E p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r)'
+
+LEMMA LemRootProgress ==
+    ASSUME NEW o \in Object, NEW r \in Object \union Task, NEW n \in Nat
+    PROVE LET S == AncestorSubGraph(deps, o, IsOpenNode).node
+              C == Cardinality(S)
+              IsMRoot(o, r) == \E p \in MaximalOpenPath(deps, o, IsOpenNode) : p[1] = r
+          IN /\ []GraphSafetyInv /\ [][Next]_vars /\ []Fairness
+             /\ [](o \in objectTargets /\ o \in RegisteredObject)
+             /\ [][S' \subseteq S]_S
+             => C = n + 1 /\ IsMRoot(o, r) ~> C < n + 1
+
+LEMMA LemCardinalityDescent ==
+    ASSUME NEW o \in Object, NEW n \in Nat
+    PROVE LET S == AncestorSubGraph(deps, o, IsOpenNode).node
+              C == Cardinality(S)
+          IN /\ []GraphSafetyInv /\ [][Next]_vars /\ []Fairness
+             /\ [](o \in objectTargets /\ o \in RegisteredObject)
+             /\ [][S' \subseteq S]_S
+             => C = n + 1 ~> C < n + 1
+
+THEOREM GP1_RefineObjectProcessing1 == Spec => RefineObjectProcessing1
+================================================================================

--- a/specs/GraphProcessing2.tla
+++ b/specs/GraphProcessing2.tla
@@ -399,21 +399,4 @@ GP1Abs == INSTANCE GraphProcessing1
 RefineGraphProcessing1 ==
     GP1Abs!Spec
 
--------------------------------------------------------------------------------
-
-(*****************************************************************************)
-(* THEOREMS                                                                  *)
-(*****************************************************************************)
-
-THEOREM Spec => []TypeOk
-THEOREM Spec => []GraphStateIntegrity
-THEOREM Spec => []CompletedObjectHasDerivation
-THEOREM Spec => []DerivableObjectRegistered
-THEOREM Spec => AbortedObjectTaskDependenciesInvariant
-THEOREM Spec => OutputObjectsEventualFinalization
-THEOREM Spec => UnderivableObjectsEventualAbortion
-THEOREM Spec => RefineTaskProcessing2
-THEOREM Spec => RefineObjectProcessing2
-THEOREM Spec => RefineGraphProcessing1
-
 ================================================================================

--- a/specs/ObjectProcessing1Theorems.tla
+++ b/specs/ObjectProcessing1Theorems.tla
@@ -1,0 +1,29 @@
+----------------------- MODULE ObjectProcessing1Theorems -----------------------
+EXTENDS ObjectProcessing1
+
+LEMMA LemType == Init /\ [][Next]_vars => []TypeOk
+
+THEOREM OP1_Type == Spec => []TypeOk
+
+LEMMA LemTargetValidity == Init /\ [][Next]_vars => []TargetValidity
+
+THEOREM OP1_TargetValidity == Spec => []TargetValidity
+
+ObjectSafetyInv ==
+    /\ TypeOk
+    /\ TargetValidity
+
+LEMMA LemObjectSafetyInv == Init /\ [][Next]_vars => []ObjectSafetyInv
+
+THEOREM OP1_ObjectSafetyInv == Spec => []ObjectSafetyInv
+
+THEOREM OP1_PermanentFinalization == Spec => PermanentFinalization
+
+LEMMA LemTargetsAreKnown ==
+        ASSUME NEW o \in objectTargets, ObjectSafetyInv
+        PROVE o \in RegisteredObject \/ o \in FinalizedObject
+
+THEOREM OP1_EventualTargetFinalizationCorrect == Spec => EventualTargetFinalization
+
+THEOREM OP1_EventualTargetResolution == Spec => EventualTargetResolution
+================================================================================

--- a/specs/ObjectProcessing2Theorems.tla
+++ b/specs/ObjectProcessing2Theorems.tla
@@ -1,0 +1,18 @@
+----------------------- MODULE ObjectProcessing2Theorems -----------------------
+EXTENDS ObjectProcessing2
+
+LEMMA SameAssumptions == OP2Assumptions <=> OP1!OP1Assumptions
+
+LEMMA LemType == Init /\ [][Next]_vars => []TypeOk
+
+THEOREM OP2_Type == Spec => []TypeOk
+
+LEMMA LemRefineObjectProcessing1InitNext == Init /\ [][Next]_vars
+                                            => OP1!Init /\ [][OP1!Next]_OP1!vars
+
+LEMMA LemTargetValidity == Init /\ [][Next]_vars => []OP1!TargetValidity
+
+THEOREM OP2_PermanentFinalization == Spec => PermanentFinalization
+
+THEOREM OP2_RefineObjectProcessing1 == Spec => RefineObjectProcessing1
+================================================================================

--- a/specs/ObjectProcessing3Theorems.tla
+++ b/specs/ObjectProcessing3Theorems.tla
@@ -1,0 +1,42 @@
+----------------------- MODULE ObjectProcessing3Theorems -----------------------
+EXTENDS ObjectProcessing3
+
+LEMMA SameAssumptions == OP3Assumptions <=> OP2!OP2Assumptions
+
+LEMMA LemType == Init /\ [][Next]_vars => []TypeOk
+
+THEOREM OP3_Type == Spec => []TypeOk
+
+LEMMA LemDeletionValidity == Init /\ [][Next]_vars => []DeletionValidity
+
+THEOREM OP3_DeletionValidity == Spec => []DeletionValidity
+
+LEMMA LemRefineObjectProcessing2InitNext == Init /\ [][Next]_vars
+                                         => OP2!Init /\ [][OP2!Next]_OP2!vars
+
+LEMMA LemTargetValidity == Init /\ [][Next]_vars => []OP2!OP1!TargetValidity
+
+LEMMA LemRegisteredTargetsUndeleted == Init /\ [][Next]_vars => []RegisteredTargetsUndeleted
+
+THEOREM OP3_RegisteredTargetsUndeleted == Spec => []RegisteredTargetsUndeleted
+
+ObjectSafetyInv ==
+    /\ TypeOk
+    /\ OP2!OP1!TargetValidity
+    /\ DeletionValidity
+    /\ RegisteredTargetsUndeleted
+
+LEMMA LemObjectSafetyInv == Init /\ [][Next]_vars => []ObjectSafetyInv
+
+THEOREM OP3_ObjectSafetyInv == Spec => []ObjectSafetyInv
+
+LEMMA LemPermanentDeletion ==
+        ASSUME NEW o \in Object
+        PROVE o \in objectDeleted /\ [Next]_vars => (o \in objectDeleted)'
+
+THEOREM OP3_PermanentDeletion == Spec => PermanentDeletion
+
+THEOREM OP3_DeletionQuiescence == Spec => DeletionQuiescence
+
+THEOREM OP3_RefineObjectProcessing2 == Spec => RefineObjectProcessing2
+================================================================================

--- a/specs/SessionProcessing1Theorems.tla
+++ b/specs/SessionProcessing1Theorems.tla
@@ -1,0 +1,11 @@
+---------------------- MODULE SessionProcessing1Theorems -----------------------
+EXTENDS SessionProcessing1
+
+LEMMA LemType == Init /\ [][Next]_vars => []TypeOk
+
+THEOREM SP1_Type == Spec => []TypeOk
+
+THEOREM SP1_PermanentDeletion == Spec => PermanentDeletion
+
+THEOREM SP1_PausedSessionEventualResolution == Spec => PausedSessionEventualResolution
+================================================================================

--- a/specs/TaskProcessing2Theorems.tla
+++ b/specs/TaskProcessing2Theorems.tla
@@ -1,0 +1,337 @@
+------------------------ MODULE TaskProcessing2Theorems ------------------------
+EXTENDS TaskProcessing2
+
+LEMMA SameAssumptions == TP2Assumptions => TP1!TP1Assumptions
+
+(**
+ * If t has no outgoing edge in NextAttemptOfRel, it has no outgoing TC-edge.
+ *)
+LEMMA TC_NoOutgoingPath ==
+    ASSUME NEW t \in Task, nextAttemptOf[t] \notin Task
+    PROVE  \A z \in Task : <<t, z>> \notin TCNextAttemptOfRel
+
+(**
+ * If no edge in NextAttemptOfRel points to t, it has no incoming TC-edge.
+ *)
+LEMMA TC_NoIncomingPath ==
+    ASSUME NEW t \in Task,
+           \A v \in Task : nextAttemptOf[v] # t
+    PROVE  \A x \in Task : <<x, t>> \notin TCNextAttemptOfRel
+
+(**
+ * Transitive closure is monotone in its relation argument.  If Rext extends
+ * NextAttemptOfRel (on Task), then TCNextAttemptOfRel is contained in the
+ * transitive closure of Rext.
+ *)
+LEMMA TC_MonotoneOnTask ==
+    ASSUME NEW Rext \in SUBSET (Task \X Task),
+           NextAttemptOfRel \cap (Task \X Task) \subseteq Rext
+    PROVE  TCNextAttemptOfRel \subseteq TransitiveClosureOn(Rext, Task)
+
+(**
+ * Reachability closure: any predicate preserved by single NextAttemptOfRel
+ * steps is preserved by TC steps.  This is the natural induction principle
+ * for transitive-closure reachability.
+ *)
+LEMMA TC_ReachabilityClosure ==
+    ASSUME NEW P(_),
+           \A a, b \in Task : <<a, b>> \in NextAttemptOfRel /\ P(a) => P(b)
+    PROVE  \A a, b \in Task : <<a, b>> \in TCNextAttemptOfRel /\ P(a) => P(b)
+
+(**
+ * At Init, the next-attempt relation is empty, hence so is its TC.
+ *)
+LEMMA LemInitTCEmpty ==
+    ASSUME Init
+    PROVE  TCNextAttemptOfRel = {}
+
+(**
+ * Structural consequences of a SetTaskRetries(T, U) step that do not depend
+ * on TaskAttemptsIntegrity.  Used by LemTaskAttemptsIntegrity (which is
+ * proving TaskAttemptsIntegrity and so cannot assume it).
+ *)
+LEMMA SetTaskRetriesUnpack ==
+    ASSUME TypeOk,
+           NEW T \in SUBSET Task, NEW U \in SUBSET Task, SetTaskRetries(T, U),
+           NEW f \in Bijection(T, U),
+           nextAttemptOf' = [s \in Task |->
+                                IF s \in T THEN f[s] ELSE nextAttemptOf[s]]
+    PROVE  /\ T \subseteq UnretriedTask
+           /\ U \subseteq UnknownTask
+           /\ T \cap U = {}
+           /\ \A a, b \in T : f[a] = f[b] => a = b
+           /\ \A s \in T : f[s] \in U
+           /\ \A u \in U : \E s \in T : f[s] = u
+           /\ \A u \in U : \A v \in Task : nextAttemptOf[v] # u
+           /\ \A s \in T : nextAttemptOf[s] = NULL
+           /\ UNCHANGED taskState
+           /\ \A s \in Task :
+                nextAttemptOf'[s] = (IF s \in T THEN f[s] ELSE nextAttemptOf[s])
+
+(**
+ * SetTaskRetriesUnpack augmented with the fact that elements of U have no
+ * outgoing nextAttemptOf-edge (which follows from TaskAttemptsIntegrity).
+ *)
+LEMMA SetTaskRetriesUnpackWithTAI ==
+    ASSUME TypeOk, TaskAttemptsIntegrity,
+           NEW T \in SUBSET Task, NEW U \in SUBSET Task, SetTaskRetries(T, U),
+           NEW f \in Bijection(T, U),
+           nextAttemptOf' = [s \in Task |->
+                                IF s \in T THEN f[s] ELSE nextAttemptOf[s]]
+    PROVE  /\ T \subseteq UnretriedTask
+           /\ U \subseteq UnknownTask
+           /\ T \cap U = {}
+           /\ \A a, b \in T : f[a] = f[b] => a = b
+           /\ \A s \in T : f[s] \in U
+           /\ \A u \in U : \E s \in T : f[s] = u
+           /\ \A u \in U : \A v \in Task : nextAttemptOf[v] # u
+           /\ \A s \in T : nextAttemptOf[s] = NULL
+           /\ \A u \in U : nextAttemptOf[u] = NULL
+           /\ UNCHANGED taskState
+           /\ \A s \in Task :
+                nextAttemptOf'[s] = (IF s \in T THEN f[s] ELSE nextAttemptOf[s])
+
+LEMMA LemType == Init /\ [][Next]_vars => []TypeOk
+
+THEOREM TP2_Type == Spec => []TypeOk
+
+LEMMA LemTaskAttemptsIntegrity == Init /\ [][Next]_vars => []TaskAttemptsIntegrity
+
+THEOREM TP2_TaskAttemptsIntegrity == Spec => []TaskAttemptsIntegrity
+
+FiniteKnownTasks ==
+    IsFiniteSet(Task \ UnknownTask)
+
+LEMMA LemFiniteKnownTasks == Init /\ [][Next]_vars => []FiniteKnownTasks
+
+AttemptsBoundsInv ==
+    \A t \in Task:
+        /\ Cardinality(TaskAttempts(t)) <= MaxRetries
+        /\ t \in UnretriedTask => Cardinality(PreviousAttempts(t)) < MaxRetries
+
+(******************************************************************************)
+(* Helper lemmas about transitive closure after a SetTaskRetries step.        *)
+(*                                                                            *)
+(* The key technical lemma is LemTC_AfterSetTaskRetries, which characterizes  *)
+(* TCNextAttemptOfRel' in terms of TCNextAttemptOfRel plus the new edges      *)
+(* <<s, f[s]>> for s \in T. Its proof uses TransitiveClosure-  *)
+(* Minimal with the closure U of the RHS set and exploits the key properties  *)
+(* of the isolated new edges: elements of T have no outgoing R-edges and      *)
+(* elements of U have neither incoming nor outgoing R-edges.                  *)
+(*                                                                            *)
+(* The three specific lemmas (LemPreviousAttemptsInU, LemTaskAttemptsInT,     *)
+(* LemTaskAttemptsOutTU) are then derived from this characterization via      *)
+(* set-theoretic case analysis on t's role in the update.                     *)
+(******************************************************************************)
+
+(**
+ * A task without an outgoing edge has no forward chain.
+ *)
+LEMMA LemUnretriedHasNoNextAttempts ==
+    ASSUME TypeOk, NEW t \in Task, t \in UnretriedTask
+    PROVE  NextAttempts(t) = {}
+
+(**
+ * Characterization of TCNextAttemptOfRel' after a SetTaskRetries(T, U) step.
+ * Left unproved -- the proof would proceed by
+ *   - showing NextAttemptOfRel' = NextAttemptOfRel \cup {<<s, f[s]>>: s \in T}
+ *     (because T elements have no outgoing R-edges);
+ *   - defining W as the right-hand side of the <=> and showing that W contains
+ *     NextAttemptOfRel' \cap (Task \X Task) and is transitively closed on Task
+ *     (using that U elements have no incoming or outgoing R-edges, so new
+ *     edges do not compose with old ones except as described);
+ *   - applying TransitiveClosureMinimal to get TCNextAttemptOfRel' \subseteq W,
+ *     and the reverse containment by direct construction.
+ *)
+LEMMA LemTC_AfterSetTaskRetries ==
+    ASSUME TypeOk, TaskAttemptsIntegrity,
+           NEW T \in SUBSET Task, NEW U \in SUBSET Task, SetTaskRetries(T, U),
+           NEW f \in Bijection(T, U),
+           nextAttemptOf' = [s \in Task |-> IF s \in T THEN f[s] ELSE nextAttemptOf[s]]
+    PROVE  \A x, y \in Task :
+              <<x, y>> \in TCNextAttemptOfRel'
+              <=> \/ <<x, y>> \in TCNextAttemptOfRel
+                  \/ \E s \in T : /\ y = f[s]
+                                  /\ \/ x = s
+                                     \/ <<x, s>> \in TCNextAttemptOfRel
+
+(**
+ * For an element of U (unknown, with no incoming edges pre-update), the new
+ * set of predecessors after SetTaskRetries is exactly {s} \cup PreviousAttempts(s)
+ * for the unique s \in T with f[s] = t, and the forward chain stays empty.
+ *)
+LEMMA LemPreviousAttemptsInU ==
+    ASSUME TypeOk, TaskAttemptsIntegrity,
+           NEW T \in SUBSET Task, NEW U \in SUBSET Task, SetTaskRetries(T, U),
+           NEW t \in U,
+           NEW f \in Bijection(T, U),
+           nextAttemptOf' = [s \in Task |-> IF s \in T THEN f[s] ELSE nextAttemptOf[s]],
+           NEW s \in T, f[s] = t
+    PROVE  /\ PreviousAttempts(t)' = {s} \cup PreviousAttempts(s)
+           /\ NextAttempts(t)' = {}
+           /\ s \notin PreviousAttempts(s)
+
+(**
+ * For t \in T, the forward chain after the update is {f[t]}, and the backward
+ * chain is unchanged. f[t] is fresh and not in PreviousAttempts(t).
+ *)
+LEMMA LemTaskAttemptsInT ==
+    ASSUME TypeOk, TaskAttemptsIntegrity,
+           NEW T \in SUBSET Task, NEW U \in SUBSET Task, SetTaskRetries(T, U),
+           NEW t \in T,
+           NEW f \in Bijection(T, U),
+           nextAttemptOf' = [s \in Task |-> IF s \in T THEN f[s] ELSE nextAttemptOf[s]]
+    PROVE  /\ NextAttempts(t)' = {f[t]}
+           /\ PreviousAttempts(t)' = PreviousAttempts(t)
+           /\ f[t] \notin PreviousAttempts(t)
+
+(**
+ * Finiteness of TaskAttempts(t). Stated as a temporal invariant: every task
+ * has a finite set of attempts. Note that IsFiniteSet(PreviousAttempts(t))
+ * follows from this and FS_Subset because
+ *    PreviousAttempts(t) \subseteq TaskAttempts(t)
+ * by the definition of TaskAttempts.
+ *)
+FiniteTaskAttemptsInv ==
+    \A t \in Task: IsFiniteSet(TaskAttempts(t))
+
+(**
+ * Acyclicity of the next-attempt relation: no task is its own TC-predecessor.
+ * This is an inductive invariant.
+ *)
+Acyclic == \A t \in Task: <<t, t>> \notin TCNextAttemptOfRel
+
+LEMMA LemAcyclic == Init /\ [][Next]_vars => []Acyclic
+
+THEOREM TP2_Acyclic == Spec => []Acyclic
+
+(**
+ * ChopFirst: if there is a TC path from a to c through nextAttemptOf and
+ * nextAttemptOf[a] = b is a task distinct from c, then there is a TC path
+ * from b to c. Proved using TransitiveClosureMinimal with a clever V capturing
+ * "b reaches y" for any y reachable from a, b, or any TC-successor of b.
+ *)
+LEMMA LemChopFirst ==
+    ASSUME NEW a \in Task, NEW c \in Task,
+           <<a, c>> \in TCNextAttemptOfRel,
+           nextAttemptOf[a] \in Task,
+           nextAttemptOf[a] # c
+    PROVE  <<nextAttemptOf[a], c>> \in TCNextAttemptOfRel
+
+(**
+ * Chain linearity: two TC-predecessors of a common task are comparable, i.e.,
+ * either equal or one is a TC-predecessor of the other. Proved by induction on
+ * Cardinality(PreviousAttempts(zz)), using Acyclic and injectivity.
+ *)
+LEMMA LemChainLinear ==
+    ASSUME TypeOk, TaskAttemptsIntegrity, Acyclic,
+           NEW xx \in Task, NEW yy \in Task, NEW zz \in Task,
+           <<xx, zz>> \in TCNextAttemptOfRel,
+           <<yy, zz>> \in TCNextAttemptOfRel,
+           IsFiniteSet(PreviousAttempts(zz))
+    PROVE  xx = yy \/ <<xx, yy>> \in TCNextAttemptOfRel \/ <<yy, xx>> \in TCNextAttemptOfRel
+
+(**
+ * For t \notin T \cup U: the backward chain is unchanged. The forward chain
+ * either is unchanged (if it doesn't reach any element of T) or gains exactly
+ * the new retry f[s0] of its tail s0 \in T; in the latter case TaskAttempts(t)
+ * and PreviousAttempts(s0) have the same cardinality before the update.
+ *)
+LEMMA LemTaskAttemptsOutTU ==
+    ASSUME TypeOk, TaskAttemptsIntegrity, FiniteTaskAttemptsInv, Acyclic,
+           NEW T \in SUBSET Task, NEW U \in SUBSET Task, SetTaskRetries(T, U),
+           NEW t \in Task, t \notin T, t \notin U,
+           NEW f \in Bijection(T, U),
+           nextAttemptOf' = [s \in Task |-> IF s \in T THEN f[s] ELSE nextAttemptOf[s]]
+    PROVE  /\ PreviousAttempts(t)' = PreviousAttempts(t)
+           /\ \/ /\ NextAttempts(t) \cap T = {}
+                 /\ NextAttempts(t)' = NextAttempts(t)
+              \/ \E s0 \in NextAttempts(t) \cap T :
+                    /\ NextAttempts(t)' = NextAttempts(t) \cup {f[s0]}
+                    /\ f[s0] \notin TaskAttempts(t)
+                    /\ IsFiniteSet(TaskAttempts(t))
+                    /\ IsFiniteSet(PreviousAttempts(s0))
+                    /\ Cardinality(TaskAttempts(t))
+                       = Cardinality(PreviousAttempts(s0))
+
+LEMMA LemTaskAttemptsFinite == Init /\ [][Next]_vars => []FiniteTaskAttemptsInv
+
+THEOREM TP2_FiniteTaskAttemptsInv == Spec => []FiniteTaskAttemptsInv
+
+LEMMA LemAttemptsBoundsInv == Init /\ [][Next]_vars => []AttemptsBoundsInv
+
+LEMMA LemAttemptsIsBounded == Init /\ [][Next]_vars => []AttemptsIsBounded
+
+THEOREM TP2_AttemptsIsBounded == Spec => []AttemptsIsBounded
+
+ExistsFreeUnknownTask ==
+    \E t \in Task : t \in UnknownTask /\ ~ \E u \in Task: nextAttemptOf[u] = t
+
+FiniteNextAttempts ==
+    IsFiniteSet({v \in Task: nextAttemptOf[v] \in Task})
+
+LEMMA LemFiniteNextAttempts == Init /\ [][Next]_vars => []FiniteNextAttempts
+
+LEMMA LemExistsFreeUnknownTask == Init /\ [][Next]_vars => []ExistsFreeUnknownTask
+
+THEOREM TP2_ExistsFreeUnknownTask == Spec => []ExistsFreeUnknownTask
+
+TaskSafetyInv ==
+    /\ TypeOk
+    /\ TaskAttemptsIntegrity
+    /\ AttemptsBoundsInv
+    /\ ExistsFreeUnknownTask
+
+LEMMA LemTaskSafetyInv == Init /\ [][Next]_vars => []TaskSafetyInv
+
+THEOREM TP2_TaskSafetyInv == Init /\ [][Next]_vars => []TaskSafetyInv
+
+THEOREM TP2_AttemptsIsIncreasing == Spec => AttemptsIsIncreasing
+
+THEOREM TP2_PermanentFinalization == Spec => PermanentFinalization
+
+LEMMA LemFailedTaskEventualRetry ==
+    ASSUME NEW t \in Task
+    PROVE []TaskSafetyInv /\ [][Next]_vars /\ Fairness
+          => t \in UnretriedTask ~> t \in FailedTask /\ nextAttemptOf[t] \in UnknownTask
+
+THEOREM TP2_FailedTaskEventualRetry == Spec => FailedTaskEventualRetry
+
+(**
+ * Helper lemma: if Cardinality(TaskAttempts(t)) is bounded by n+1 but not
+ * always by n, then eventually Cardinality stabilizes at n+1.
+ *
+ * Extracted as a standalone lemma because LS4 (PTL) struggles when the
+ * induction hypothesis P(n) is in scope alongside an action formula over
+ * a derived set. Keeping this lemma P(n)-free makes LS4 discharge it.
+ *)
+LEMMA LemCardReachesNp1 ==
+    ASSUME NEW t \in Task, NEW n \in Nat
+    PROVE  LET A    == TaskAttempts(t)
+               I(m) == IsFiniteSet(A) /\ Cardinality(A) <= m
+           IN  ~[]I(n) /\ []I(n + 1) /\ [][A \subseteq A']_A
+               => <>[](IsFiniteSet(A) /\ Cardinality(A) = n + 1)
+
+(**
+ * Helper lemma: once Cardinality(TaskAttempts(t)) stabilizes at n+1 and
+ * TaskAttempts(t) is monotonically growing, the set itself stabilizes.
+ *
+ * Extracted as a standalone lemma for the same LS4-scoping reason as above.
+ *)
+LEMMA LemCardFixedImpliesSetFixed ==
+    ASSUME NEW t \in Task, NEW n \in Nat
+    PROVE  LET A == TaskAttempts(t)
+           IN  <>[](IsFiniteSet(A) /\ Cardinality(A) = n + 1) /\ [][A \subseteq A']_A
+               => <>[][A = A']_A
+
+THEOREM TP2_AttemptsEventualStability == Spec => AttemptsEventualStability
+
+LEMMA LemFailedTaskEventualFinalization ==
+    ASSUME NEW t \in Task
+    PROVE []TaskSafetyInv /\ [][Next]_vars /\ Fairness
+          => t \in FailedTask ~> t \in RetriedTask
+
+THEOREM TP2_EventualFinalization == Spec => EventualFinalization
+
+THEOREM TP2_RefineTaskProcessing1 == Spec => RefineTaskProcessing1
+================================================================================

--- a/specs/TaskProcessing3.tla
+++ b/specs/TaskProcessing3.tla
@@ -385,16 +385,4 @@ TP2 ==
         WITH taskState <- taskStateBar
 RefineTaskProcessing2 == TP2!Spec
 
--------------------------------------------------------------------------------
-
-(*****************************************************************************)
-(* THEOREMS                                                                  *)
-(*****************************************************************************)
-
-THEOREM Spec => []TypeOk
-THEOREM Spec => []TaskStateIntegrity
-THEOREM Spec => PermanentStopping
-THEOREM Spec => RequestedStoppingEventualAcknowledgment
-THEOREM Spec => RefineTaskProcessing2
-
 ================================================================================

--- a/specs/TaskProcessing3Theorems.tla
+++ b/specs/TaskProcessing3Theorems.tla
@@ -1,0 +1,33 @@
+------------------------ MODULE TaskProcessing3Theorems ------------------------
+EXTENDS TaskProcessing3
+
+LEMMA SameAssumptions == TP3Assumptions => TP2!TP2Assumptions
+
+LEMMA LemType == Init /\ [][Next]_vars => []TypeOk
+
+THEOREM TP3_Type == Spec => []TypeOk
+
+LEMMA LemTaskStateIntegrity == Init /\ [][Next]_vars => []TaskStateIntegrity
+
+THEOREM TP3_TaskStateIntegrity == Spec => []TaskStateIntegrity
+
+LEMMA LemPermanentStoppingStep ==
+    ASSUME NEW t \in Task
+    PROVE t \in StoppedTask /\ [Next /\ ~ \E T \in SUBSET Task: t \in T /\ DiscardTasks(T)]_vars
+          => (t \in StoppedTask)'
+
+THEOREM TP3_PermanentStopping == Spec => PermanentStopping
+
+TaskSafetyInv ==
+    /\ TypeOk
+    /\ TaskStateIntegrity
+
+LEMMA LemTaskSafetyInv == Init /\ [][Next]_vars => []TaskSafetyInv
+
+THEOREM TP3_TaskSafetyInv == Spec => []TaskSafetyInv
+
+THEOREM TP3_RequestedStoppingEventualAcknowledgment ==
+    Spec => RequestedStoppingEventualAcknowledgment
+
+THEOREM TP3_RefineTaskProcessing2 == Spec => RefineTaskProcessing2
+================================================================================

--- a/specs/TaskProcessing4.tla
+++ b/specs/TaskProcessing4.tla
@@ -414,16 +414,4 @@ DeletionQuiescence ==
 TP3 == INSTANCE TaskProcessing3
 RefineTaskProcessing3 == TP3!Spec
 
--------------------------------------------------------------------------------
-
-(*****************************************************************************)
-(* THEOREMS                                                                  *)
-(*****************************************************************************)
-
-THEOREM Spec => []TypeOk
-THEOREM Spec => []DeletionValidity
-THEOREM Spec => PermanentDeletion
-THEOREM Spec => DeletionQuiescence
-THEOREM Spec => RefineTaskProcessing3
-
 ================================================================================

--- a/specs/TaskProcessing4Theorems.tla
+++ b/specs/TaskProcessing4Theorems.tla
@@ -1,0 +1,31 @@
+------------------------ MODULE TaskProcessing4Theorems ------------------------
+EXTENDS TaskProcessing4
+
+LEMMA SameAssumptions == TP4Assumptions => TP3!TP3Assumptions
+
+LEMMA LemType == Init /\ [][Next]_vars => []TypeOk
+
+THEOREM TP4_Type == Spec => []TypeOk
+
+LEMMA LemDeletionValidity == Init /\ [][Next]_vars => []DeletionValidity
+
+THEOREM TP4_DeletionValidity == Spec => []DeletionValidity
+
+TaskSafetyInv ==
+    /\ TypeOk
+    /\ DeletionValidity
+
+LEMMA LemTaskSafetyInv == Init /\ [][Next]_vars => []TaskSafetyInv
+
+THEOREM TP4_TaskSafetyInv == Spec => []TaskSafetyInv
+
+LEMMA LemPermanentDeletion ==
+        ASSUME NEW t \in Task
+        PROVE t \in taskDeleted /\ [Next]_vars => (t \in taskDeleted)'
+
+THEOREM TP4_PermanentDeletion == Spec => PermanentDeletion
+
+THEOREM TP4_DeletionQuiescence == Spec => DeletionQuiescence
+
+THEOREM TP4_RefineTaskProcessing3 == Spec => RefineTaskProcessing3
+================================================================================


### PR DESCRIPTION
## Summary

Give every specification that carries proofs the same three-file layout already used by TaskProcessing1 and the library modules:
* X.tla          - the specification
* XTheorems.tla  - public (unproved) theorem declarations
* X_proofs.tla   - the TLAPS proofs

Add the missing XTheorems modules for ObjectProcessing1-3,
SessionProcessing1, TaskProcessing2-4 and GraphProcessing1, each mirroring the statements of its _proofs module (proof bodies stripped) plus the auxiliary invariants those statements reference.

Remove the inline THEOREM blocks at the bottom of GraphProcessing1, GraphProcessing2, TaskProcessing3 and TaskProcessing4 so that theorems are declared only in the XTheorems modules.
