### PR TITLE
feat: add OBJECT_PURGED status and PurgeObjects action to ObjectProcessing3

### DIFF
--- a/specs/ObjectProcessing3.cfg
+++ b/specs/ObjectProcessing3.cfg
@@ -9,8 +9,10 @@ INVARIANTS
     TypeOk
     DeletionValidity
     RegisteredTargetsUndeleted
+    DeletionNoData
 
 PROPERTIES
     PermanentDeletion
+    PermanentPurgation
     \* DeletionQuiescence
     RefineObjectProcessing2

--- a/specs/ObjectProcessing3.tla
+++ b/specs/ObjectProcessing3.tla
@@ -29,9 +29,21 @@ vars == << objectState, objectTargets, objectDeleted >>
 INSTANCE ObjectStates
 
 (**
+ * REFINEMENT MAPPING
+ * Projects the OP3-specific OBJECT_PURGED state back onto OBJECT_COMPLETED, so
+ * that a purged object (a completed object whose data has been freed) is seen
+ * as completed by ObjectProcessing2, which has no notion of purgation.
+ *)
+objectStateBar ==
+    [o \in Object |->
+        IF objectState[o] = OBJECT_PURGED
+            THEN OBJECT_COMPLETED
+            ELSE objectState[o]]
+
+(**
  * Imports ObjectProcessing2 definitions.
  *)
-OP2 == INSTANCE ObjectProcessing2_proofs
+OP2 == INSTANCE ObjectProcessing2_proofs WITH objectState <- objectStateBar
 
 (**
  * TYPE INVARIANT
@@ -117,13 +129,26 @@ AbortObjects(O) ==
     /\ UNCHANGED << objectTargets, objectDeleted >>
 
 (**
- * OBJECT FINALIZATION
+ * OBJECT PURGATION
+ * A set 'O' of completed objects is purged, meaning that their data has been
+ * freed to reclaim space. Their metadata is kept, but the data is no longer
+ * available for execution or user retrieval.
+ *)
+PurgeObjects(O) ==
+    /\ O /= {} /\ O \subseteq CompletedObject
+    /\ objectState' =
+        [o \in Object |-> IF o \in O THEN OBJECT_PURGED ELSE objectState[o]]
+    /\ UNCHANGED << objectTargets, objectDeleted >>
+
+(**
+ * OBJECT DELETION
  * A set 'O' of objects is deleted, meaning that the system no longer has
- * knowledge of these objects (metadata and associated data).
+ * knowledge of these objects (metadata and associated data). Only objects
+ * holding no data can be deleted, i.e. registered, aborted or purged objects.
  *)
 DeleteObjects(O) ==
     /\ O /= {}
-    /\ O \intersect UnknownObject = {}
+    /\ O \subseteq UNION {RegisteredObject, AbortedObject, PurgedObject}
     /\ O \intersect objectTargets \intersect RegisteredObject = {}
     /\ objectDeleted' = objectDeleted \union O
     /\ UNCHANGED << objectState, objectTargets >>
@@ -134,7 +159,7 @@ DeleteObjects(O) ==
  * targeted objects have been completed or aborted.
  *)
 Terminating ==
-    /\ objectTargets \subseteq (CompletedObject \union AbortedObject)
+    /\ objectTargets \subseteq (CompletedObject \union AbortedObject \union PurgedObject)
     /\ UNCHANGED vars
 
 -------------------------------------------------------------------------------
@@ -154,6 +179,7 @@ Next ==
         \/ UntargetObjects(O)
         \/ CompleteObjects(O)
         \/ AbortObjects(O)
+        \/ PurgeObjects(O)
         \/ DeleteObjects(O)
     \/ Terminating
 
@@ -198,9 +224,26 @@ RegisteredTargetsUndeleted ==
     \A o \in Object:
         o \in RegisteredObject /\ o \in objectTargets => ~ o \in objectDeleted
 
+(**
+ * SAFETY
+ * A deleted object holds no data: it is registered, aborted or purged. In
+ * particular, no completed object is ever deleted (it must be purged first).
+ *)
+DeletionNoData ==
+    /\ objectDeleted \subseteq UNION {RegisteredObject, AbortedObject, PurgedObject}
+    /\ CompletedObject \intersect objectDeleted = {}
+
 PermanentDeletion ==
     \A o \in Object:
         [](o \in objectDeleted => [](o \in objectDeleted))
+
+(**
+ * SAFETY
+ * Once an object has been purged, it remains purged permanently.
+ *)
+PermanentPurgation ==
+    \A o \in Object:
+        [](o \in PurgedObject => [](o \in PurgedObject))
 
 (**
  * SAFETY

--- a/specs/ObjectProcessing3Theorems.tla
+++ b/specs/ObjectProcessing3Theorems.tla
@@ -11,6 +11,10 @@ LEMMA LemDeletionValidity == Init /\ [][Next]_vars => []DeletionValidity
 
 THEOREM OP3_DeletionValidity == Spec => []DeletionValidity
 
+LEMMA LemDeletionNoData == Init /\ [][Next]_vars => []DeletionNoData
+
+THEOREM OP3_DeletionNoData == Spec => []DeletionNoData
+
 LEMMA LemRefineObjectProcessing2InitNext == Init /\ [][Next]_vars
                                          => OP2!Init /\ [][OP2!Next]_OP2!vars
 
@@ -25,6 +29,7 @@ ObjectSafetyInv ==
     /\ OP2!OP1!TargetValidity
     /\ DeletionValidity
     /\ RegisteredTargetsUndeleted
+    /\ DeletionNoData
 
 LEMMA LemObjectSafetyInv == Init /\ [][Next]_vars => []ObjectSafetyInv
 
@@ -35,6 +40,8 @@ LEMMA LemPermanentDeletion ==
         PROVE o \in objectDeleted /\ [Next]_vars => (o \in objectDeleted)'
 
 THEOREM OP3_PermanentDeletion == Spec => PermanentDeletion
+
+THEOREM OP3_PermanentPurgation == Spec => PermanentPurgation
 
 THEOREM OP3_DeletionQuiescence == Spec => DeletionQuiescence
 

--- a/specs/ObjectProcessing3_proofs.tla
+++ b/specs/ObjectProcessing3_proofs.tla
@@ -1,7 +1,8 @@
 ----------------------- MODULE ObjectProcessing3_proofs ------------------------
 EXTENDS ObjectProcessing3, TLAPS
 
-USE DEF OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_COMPLETED, OBJECT_ABORTED
+USE DEF OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_COMPLETED, OBJECT_ABORTED,
+OBJECT_PURGED
 
 LEMMA SameAssumptions == OP3Assumptions <=> OP2!OP2Assumptions
 BY DEF IsDenumerableSet, ExistsBijection, Bijection, Injection, Surjection,
@@ -14,7 +15,7 @@ LEMMA LemType == Init /\ [][Next]_vars => []TypeOk
     BY DEF Init
 <1>2. TypeOk /\ [Next]_vars => TypeOk'
     BY DEF Next, vars, RegisterObjects, TargetObjects, UntargetObjects,
-    CompleteObjects, AbortObjects, DeleteObjects, Terminating
+    CompleteObjects, AbortObjects, PurgeObjects, DeleteObjects, Terminating
 <1>. QED
     BY <1>1, <1>2, PTL
 
@@ -27,23 +28,67 @@ LEMMA LemDeletionValidity == Init /\ [][Next]_vars => []DeletionValidity
     BY DEF Init
 <1>2. DeletionValidity /\ [Next]_vars => DeletionValidity'
     BY DEF Next, vars, RegisterObjects, TargetObjects, UntargetObjects,
-    CompleteObjects, AbortObjects, DeleteObjects, Terminating
+    CompleteObjects, AbortObjects, PurgeObjects, DeleteObjects, Terminating,
+    RegisteredObject, AbortedObject, PurgedObject
 <1>. QED
     BY <1>1, <1>2, PTL
 
 THEOREM OP3_DeletionValidity == Spec => []DeletionValidity
 BY LemDeletionValidity DEF Spec
 
+LEMMA LemDeletionNoData == Init /\ [][Next]_vars => []DeletionNoData
+<1>. USE DEF DeletionNoData, UnknownObject, RegisteredObject, CompletedObject,
+     AbortedObject, PurgedObject
+<1>1. Init => DeletionNoData
+    BY DEF Init
+<1>2. DeletionNoData /\ [Next]_vars => DeletionNoData'
+    <2>. SUFFICES ASSUME DeletionNoData, [Next]_vars
+                  PROVE DeletionNoData'
+        OBVIOUS
+    <2>1. ASSUME NEW O \in SUBSET Object, RegisterObjects(O)
+          PROVE DeletionNoData'
+        BY <2>1 DEF RegisterObjects
+    <2>2. ASSUME NEW O \in SUBSET Object, TargetObjects(O)
+          PROVE DeletionNoData'
+        BY <2>2 DEF TargetObjects
+    <2>3. ASSUME NEW O \in SUBSET Object, UntargetObjects(O)
+          PROVE DeletionNoData'
+        BY <2>3 DEF UntargetObjects
+    <2>4. ASSUME NEW O \in SUBSET Object, CompleteObjects(O)
+          PROVE DeletionNoData'
+        BY <2>4 DEF CompleteObjects
+    <2>5. ASSUME NEW O \in SUBSET Object, AbortObjects(O)
+          PROVE DeletionNoData'
+        BY <2>5 DEF AbortObjects
+    <2>6. ASSUME NEW O \in SUBSET Object, PurgeObjects(O)
+          PROVE DeletionNoData'
+        BY <2>6 DEF PurgeObjects
+    <2>7. ASSUME NEW O \in SUBSET Object, DeleteObjects(O)
+          PROVE DeletionNoData'
+        BY <2>7 DEF DeleteObjects
+    <2>8. CASE Terminating
+        BY <2>8 DEF Terminating, vars
+    <2>9. CASE UNCHANGED vars
+        BY <2>9 DEF vars
+    <2>. QED
+        BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8, <2>9 DEF Next
+<1>. QED
+    BY <1>1, <1>2, PTL
+
+THEOREM OP3_DeletionNoData == Spec => []DeletionNoData
+BY LemDeletionNoData DEF Spec
+
 LEMMA LemRefineObjectProcessing2InitNext == Init /\ [][Next]_vars
                                          => OP2!Init /\ [][OP2!Next]_OP2!vars
 <1>. USE DEF OP2!OBJECT_UNKNOWN, OP2!OBJECT_REGISTERED, OP2!OBJECT_COMPLETED,
      OP2!OBJECT_ABORTED
 <1>1. Init => OP2!Init
-    BY DEF Init, OP2!Init
+    BY DEF Init, OP2!Init, objectStateBar
 <1>2. [Next]_vars => [OP2!Next]_OP2!vars
     <2>. SUFFICES ASSUME [Next]_vars
                   PROVE OP2!Next \/ UNCHANGED OP2!vars
-        BY DEF vars, OP2!vars
+        BY DEF vars, OP2!vars, objectStateBar
+    <2>. USE DEF objectStateBar
     <2>1. ASSUME NEW O \in SUBSET Object, RegisterObjects(O)
           PROVE OP2!RegisterObjects(O)
         BY <2>1 DEF RegisterObjects, OP2!RegisterObjects, UnknownObject,
@@ -64,16 +109,21 @@ LEMMA LemRefineObjectProcessing2InitNext == Init /\ [][Next]_vars
           PROVE OP2!AbortObjects(O)
         BY <2>5 DEF AbortObjects, OP2!AbortObjects, RegisteredObject,
         OP2!RegisteredObject
-    <2>6. ASSUME NEW O \in SUBSET Object, DeleteObjects(O)
+    <2>6. ASSUME NEW O \in SUBSET Object, PurgeObjects(O)
           PROVE UNCHANGED OP2!vars
-        BY <2>6 DEF DeleteObjects, OP2!vars
-    <2>7. CASE Terminating
-        BY <2>7 DEF Terminating, OP2!Terminating, vars, OP2!vars,
-        CompletedObject, AbortedObject, OP2!CompletedObject, OP2!AbortedObject
-    <2>8. CASE UNCHANGED vars
-        BY <2>8 DEF vars, OP2!vars
+        BY <2>6 DEF PurgeObjects, OP2!vars, CompletedObject
+    <2>7. ASSUME NEW O \in SUBSET Object, DeleteObjects(O)
+          PROVE UNCHANGED OP2!vars
+        BY <2>7 DEF DeleteObjects, OP2!vars
+    <2>8. CASE Terminating
+        BY <2>8 DEF Terminating, OP2!Terminating, vars, OP2!vars,
+        CompletedObject, AbortedObject, PurgedObject,
+        OP2!CompletedObject, OP2!AbortedObject
+    <2>9. CASE UNCHANGED vars
+        BY <2>9 DEF vars, OP2!vars
     <2>. QED
-        BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8 DEF Next, OP2!Next
+        BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8, <2>9
+        DEF Next, OP2!Next
 <1>. QED
     BY <1>1, <1>2, PTL
 
@@ -93,7 +143,7 @@ LEMMA LemRegisteredTargetsUndeleted == Init /\ [][Next]_vars => []RegisteredTarg
           PROVE RegisteredTargetsUndeleted'
         BY <2>1 DEF RegisterObjects, UnknownObject, OP2!OP1!TargetValidity,
         OP2!OP1!UnknownObject, OP2!OP1!OBJECT_UNKNOWN, OP2!objectStateBar,
-        OP2!OBJECT_COMPLETED, OP2!OBJECT_ABORTED
+        objectStateBar, OP2!OBJECT_COMPLETED, OP2!OBJECT_ABORTED
     <2>2. ASSUME NEW O \in SUBSET Object, TargetObjects(O)
           PROVE RegisteredTargetsUndeleted'
         BY <2>2 DEF TargetObjects
@@ -106,15 +156,18 @@ LEMMA LemRegisteredTargetsUndeleted == Init /\ [][Next]_vars => []RegisteredTarg
     <2>5. ASSUME NEW O \in SUBSET Object, AbortObjects(O)
           PROVE RegisteredTargetsUndeleted'
         BY <2>5 DEF AbortObjects
-    <2>6. ASSUME NEW O \in SUBSET Object, DeleteObjects(O)
+    <2>6. ASSUME NEW O \in SUBSET Object, PurgeObjects(O)
           PROVE RegisteredTargetsUndeleted'
-        BY <2>6 DEF DeleteObjects
-    <2>7. CASE Terminating
-        BY <2>7 DEF Terminating, vars
-    <2>8. CASE UNCHANGED vars
-        BY <2>8 DEF vars
+        BY <2>6 DEF PurgeObjects
+    <2>7. ASSUME NEW O \in SUBSET Object, DeleteObjects(O)
+          PROVE RegisteredTargetsUndeleted'
+        BY <2>7 DEF DeleteObjects
+    <2>8. CASE Terminating
+        BY <2>8 DEF Terminating, vars
+    <2>9. CASE UNCHANGED vars
+        BY <2>9 DEF vars
     <2>. QED
-        BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8 DEF Next
+        BY <2>1, <2>2, <2>3, <2>4, <2>5, <2>6, <2>7, <2>8, <2>9 DEF Next
 <1>. QED
     BY <1>1, <1>2, LemTargetValidity, PTL
 
@@ -126,10 +179,11 @@ ObjectSafetyInv ==
     /\ OP2!OP1!TargetValidity
     /\ DeletionValidity
     /\ RegisteredTargetsUndeleted
+    /\ DeletionNoData
 
 LEMMA LemObjectSafetyInv == Init /\ [][Next]_vars => []ObjectSafetyInv
 BY LemType, LemDeletionValidity, LemRegisteredTargetsUndeleted,
-LemTargetValidity, PTL DEF ObjectSafetyInv
+LemTargetValidity, LemDeletionNoData, PTL DEF ObjectSafetyInv
 
 THEOREM OP3_ObjectSafetyInv == Spec => []ObjectSafetyInv
 BY LemObjectSafetyInv DEF Spec
@@ -138,7 +192,7 @@ LEMMA LemPermanentDeletion ==
         ASSUME NEW o \in Object
         PROVE o \in objectDeleted /\ [Next]_vars => (o \in objectDeleted)'
 BY DEF Next, vars, RegisterObjects, TargetObjects, UntargetObjects,
-CompleteObjects, AbortObjects, DeleteObjects, Terminating
+CompleteObjects, AbortObjects, PurgeObjects, DeleteObjects, Terminating
 
 THEOREM OP3_PermanentDeletion == Spec => PermanentDeletion
 <1>. SUFFICES ASSUME NEW o \in Object
@@ -146,6 +200,18 @@ THEOREM OP3_PermanentDeletion == Spec => PermanentDeletion
     BY DEF PermanentDeletion
 <1>1. o \in objectDeleted /\ [Next]_vars => (o \in objectDeleted)'
     BY LemPermanentDeletion
+<1>. QED
+    BY <1>1, PTL DEF Spec
+
+THEOREM OP3_PermanentPurgation == Spec => PermanentPurgation
+<1>. SUFFICES ASSUME NEW o \in Object
+              PROVE Spec => [](o \in PurgedObject => [](o \in PurgedObject))
+    BY DEF PermanentPurgation
+<1>. USE DEF Next, vars, RegisterObjects, TargetObjects, UntargetObjects,
+     CompleteObjects, AbortObjects, PurgeObjects, DeleteObjects, Terminating,
+     UnknownObject, RegisteredObject, CompletedObject, AbortedObject, PurgedObject
+<1>1. o \in PurgedObject /\ [Next]_vars => (o \in PurgedObject)'
+    OBVIOUS
 <1>. QED
     BY <1>1, PTL DEF Spec
 
@@ -157,9 +223,9 @@ THEOREM OP3_DeletionQuiescence == Spec => DeletionQuiescence
     BY DEF DeletionQuiescence
 <1>1. ObjectSafetyInv /\ o \in objectDeleted /\ [Next]_vars => /\ objectState'[o] = objectState[o]
                                                                /\ o \in objectTargets' <=> o \in objectTargets
-    BY DEF ObjectSafetyInv, DeletionValidity, Next, vars, RegisterObjects,
-    TargetObjects, UntargetObjects, CompleteObjects, AbortObjects,
-    DeleteObjects, Terminating
+    BY DEF ObjectSafetyInv, DeletionValidity, DeletionNoData, CompletedObject,
+    Next, vars, RegisterObjects, TargetObjects, UntargetObjects, CompleteObjects,
+    AbortObjects, PurgeObjects, DeleteObjects, Terminating
 <1>2. ObjectSafetyInv /\ o \in objectDeleted /\ [Next]_vars => (o \in objectDeleted)'
     BY LemPermanentDeletion
 <1>. QED
@@ -184,21 +250,30 @@ THEOREM OP3_RefineObjectProcessing2 == Spec => RefineObjectProcessing2
                 P       == ~ o \in objectDeleted
     <2>0. ENABLED <<AbsA(o)>>_OP2!vars
             => o \in objectTargets /\ o \in OP2!RegisteredObject
-        BY ExpandENABLED DEF OP2!CompleteObjects, OP2!vars
+        <3>1. AbsA(o) => objectStateBar' /= objectStateBar
+            BY DEF OP2!CompleteObjects, OP2!RegisteredObject
+        <3>2. <<AbsA(o)>>_OP2!vars <=> AbsA(o)
+            BY <3>1 DEF OP2!vars
+        <3>3. (ENABLED <<AbsA(o)>>_OP2!vars) <=> (ENABLED AbsA(o))
+            BY <3>2, ENABLEDaxioms
+        <3>4. ENABLED AbsA(o) => o \in objectTargets /\ o \in OP2!RegisteredObject
+            BY ExpandENABLED, Zenon DEF objectStateBar, OP2!CompleteObjects
+        <3>. QED
+            BY <3>3, <3>4
     <2>1. P /\ ENABLED <<AbsA(o)>>_OP2!vars => ENABLED <<A(o)>>_vars
         <4>1. ENABLED <<A(o)>>_vars
                 <=> o \in objectTargets /\ o \in RegisteredObject /\ ~ o \in objectDeleted
             BY ExpandENABLED DEF CompleteObjects, vars, RegisteredObject
         <4>2. RegisteredObject = OP2!RegisteredObject
-            BY DEF RegisteredObject, OP2!RegisteredObject
+            BY DEF RegisteredObject, OP2!RegisteredObject, objectStateBar
         <4>. QED
             BY <2>0, <4>1, <4>2
     <2>2. <<A(o)>>_vars => <<AbsA(o)>>_OP2!vars
         BY DEF CompleteObjects, OP2!CompleteObjects, vars, OP2!vars,
-        RegisteredObject, OP2!RegisteredObject
+        RegisteredObject, OP2!RegisteredObject, objectStateBar
     <2>3. ObjectSafetyInv /\ ENABLED <<AbsA(o)>>_OP2!vars => P
         BY <2>0 DEF ObjectSafetyInv, RegisteredTargetsUndeleted, RegisteredObject,
-        OP2!RegisteredObject
+        OP2!RegisteredObject, objectStateBar
     <2>. QED
         BY <2>1, <2>2, <2>3, PTL
 <1>2. []ObjectSafetyInv /\ WF_vars(o \in objectTargets /\ AbortObjects({o}))
@@ -208,22 +283,31 @@ THEOREM OP3_RefineObjectProcessing2 == Spec => RefineObjectProcessing2
                 P       == ~ o \in objectDeleted
     <2>0. ENABLED <<AbsA(o)>>_OP2!vars
             => o \in objectTargets /\ o \in OP2!RegisteredObject
-        BY ExpandENABLED DEF OP2!AbortObjects, OP2!vars
+        <3>1. AbsA(o) => objectStateBar' /= objectStateBar
+            BY DEF OP2!AbortObjects, OP2!RegisteredObject
+        <3>2. <<AbsA(o)>>_OP2!vars <=> AbsA(o)
+            BY <3>1 DEF OP2!vars
+        <3>3. (ENABLED <<AbsA(o)>>_OP2!vars) <=> (ENABLED AbsA(o))
+            BY <3>2, ENABLEDaxioms
+        <3>4. ENABLED AbsA(o) => o \in objectTargets /\ o \in OP2!RegisteredObject
+            BY ExpandENABLED, Zenon DEF objectStateBar, OP2!AbortObjects
+        <3>. QED
+            BY <3>3, <3>4
     <2>1. P /\ ENABLED <<AbsA(o)>>_OP2!vars => ENABLED <<A(o)>>_vars
         <4>1. ENABLED <<A(o)>>_vars
                 <=> o \in objectTargets /\ o \in RegisteredObject /\ ~ o \in objectDeleted
             BY ExpandENABLED DEF AbortObjects, vars, RegisteredObject
         <4>2. RegisteredObject = OP2!RegisteredObject
-            BY DEF RegisteredObject, OP2!RegisteredObject
+            BY DEF RegisteredObject, OP2!RegisteredObject, objectStateBar
         <4>. QED
             BY <2>0, <4>1, <4>2
     <2>2. <<o \in objectTargets /\ AbortObjects({o})>>_vars
             => <<o \in objectTargets /\ OP2!AbortObjects({o})>>_OP2!vars
         BY DEF AbortObjects, OP2!AbortObjects, vars, OP2!vars,
-        RegisteredObject, OP2!RegisteredObject
+        RegisteredObject, OP2!RegisteredObject, objectStateBar
     <2>3. ObjectSafetyInv /\ ENABLED <<AbsA(o)>>_OP2!vars => P
         BY <2>0 DEF ObjectSafetyInv, RegisteredTargetsUndeleted, RegisteredObject,
-        OP2!RegisteredObject
+        OP2!RegisteredObject, objectStateBar
     <2>. QED
         BY <2>1, <2>2, <2>3, PTL
 <1>. QED

--- a/specs/ObjectStates.tla
+++ b/specs/ObjectStates.tla
@@ -23,6 +23,7 @@ OBJECT_REGISTERED == "OBJECT_REGISTERED" \* Object created with only its metadat
 OBJECT_FINALIZED  == "OBJECT_FINALIZED"  \* Object has been successfully generated
 OBJECT_COMPLETED  == "OBJECT_COMPLETED"  \* Object has been generated with a non-empty data
 OBJECT_ABORTED    == "OBJECT_ABORTED"    \* Object has been genereted without any data
+OBJECT_PURGED     == "OBJECT_PURGED"     \* Completed object whose data has been freed (metadata kept)
 
 (**
  * Sets of states accessible for each level of refinement.
@@ -31,7 +32,7 @@ OP1State == {OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_FINALIZED}
 OP2State == {OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_COMPLETED,
              OBJECT_ABORTED}
 OP3State == {OBJECT_UNKNOWN, OBJECT_REGISTERED, OBJECT_COMPLETED,
-             OBJECT_ABORTED}
+             OBJECT_ABORTED, OBJECT_PURGED}
 
 (**
  * Sets of objects by state.
@@ -41,5 +42,6 @@ RegisteredObject == {o \in Object: objectState[o] = OBJECT_REGISTERED}
 FinalizedObject  == {o \in Object: objectState[o] = OBJECT_FINALIZED}
 CompletedObject  == {o \in Object: objectState[o] = OBJECT_COMPLETED}
 AbortedObject    == {o \in Object: objectState[o] = OBJECT_ABORTED}
+PurgedObject     == {o \in Object: objectState[o] = OBJECT_PURGED}
 
 ===============================================================================


### PR DESCRIPTION
## Summary

Introduces object purgation into the ObjectProcessing3 (OP3) lifecycle: a completed object's data can be freed (OBJECT_PURGED) while its metadata is kept, and object deletion is tightened to require a "no data" state. This mirrors the existing session lifecycle (SESSION_PURGED / PurgeSessions / DeleteSessions).

## Changes

- New status OBJECT_PURGED (ObjectStates.tla): added to OP3State with its PurgedObject set — a completed object whose data has been reclaimed.
- New action PurgeObjects(O): COMPLETED -> PURGED, guarded by O \subseteq CompletedObject.
- Tightened DeleteObjects(O): deletion now requires objects to hold no data — O \subseteq RegisteredObject \union AbortedObject \union PurgedObject. Completed objects must be purged before they can be deleted (targeted-registered guard unchanged).
- Update Terminating action to include purged objects.
- Refinement mapping: added objectStateBar (PURGED |-> COMPLETED) and instantiate OP2 through it, since OBJECT_PURGED \notin OP2State. Purge is a stuttering step in OP2, mirroring how deletion already is.
- New properties: invariant DeletionNoData (every deleted object is registered/aborted/purged) and safety property PermanentPurgation (once purged, always purged).

## Verification

- TLC (Object = {o,p,q}): 26,309 states / 2,744 distinct / depth 7, no violations. All invariants (TypeOk, DeletionValidity, RegisteredTargetsUndeleted, DeletionNoData) and properties (PermanentDeletion, PermanentPurgation, RefineObjectProcessing2) hold.
- TLAPS: all 222 obligations in ObjectProcessing3_proofs.tla discharged (0 omitted, 0 unproved).
